### PR TITLE
Harden public beta release diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 ENVIRONMENT=development
+APP_BUILD_SHA=local
+VITE_BUILD_SHA=local
 DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5433/collegefootballfantasy
 # Keep normal development worktrees on the same Compose project and PostgreSQL volume.
 # Override with `COMPOSE_PROJECT_NAME=cff_<purpose>` only for disposable isolated stacks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
       JWT_SECRET_KEY: ci-only-secret
       UI_BASE_URL: http://localhost:8080
       CORS_ORIGINS: http://localhost:8080
-      APP_BUILD_SHA: ${{ github.sha }}
-      VITE_BUILD_SHA: ${{ github.sha }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -84,6 +82,8 @@ jobs:
         run: npm --prefix web test
 
       - name: Build frontend
+        env:
+          VITE_BUILD_SHA: ${{ github.sha }}
         run: npm --prefix web run build
 
       - name: Install Playwright browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:
@@ -29,6 +32,8 @@ jobs:
       JWT_SECRET_KEY: ci-only-secret
       UI_BASE_URL: http://localhost:8080
       CORS_ORIGINS: http://localhost:8080
+      APP_BUILD_SHA: ${{ github.sha }}
+      VITE_BUILD_SHA: ${{ github.sha }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -87,6 +92,16 @@ jobs:
       - name: Run frontend E2E tests
         run: npm --prefix web run test:e2e
 
+      - name: Upload frontend E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-e2e-artifacts
+          path: |
+            web/playwright-report
+            web/test-results
+          if-no-files-found: ignore
+
   docker-clean-boot:
     runs-on: ubuntu-latest
     steps:
@@ -94,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build and start isolated stack
-        run: COMPOSE_PROJECT_NAME=cff_ci DB_PORT=55450 docker compose up --build -d
+        run: APP_BUILD_SHA=${GITHUB_SHA} VITE_BUILD_SHA=${GITHUB_SHA} COMPOSE_PROJECT_NAME=cff_ci DB_PORT=55450 docker compose up --build -d
 
       - name: Verify API and web readiness
         run: |
@@ -106,6 +121,20 @@ jobs:
           done
           docker compose -p cff_ci logs
           exit 1
+
+      - name: Capture isolated-stack logs
+        if: always()
+        run: |
+          mkdir -p reports/docker-clean-boot
+          docker compose -p cff_ci logs --no-color > reports/docker-clean-boot/stack.log || true
+
+      - name: Upload isolated-stack diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-clean-boot-diagnostics
+          path: reports/docker-clean-boot
+          if-no-files-found: ignore
 
       - name: Stop isolated stack
         if: always()
@@ -119,3 +148,11 @@ jobs:
 
       - name: Run real Postgres/FastAPI/frontend/lifecycle E2E
         run: ./scripts/run_real_stack_e2e.sh
+
+      - name: Upload real-stack E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-stack-e2e-artifacts
+          path: reports/real-stack-e2e
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ Thumbs.db
 /output/
 /tmp/
 /reports/draft-board-integrity-*/
+/reports/real-stack-e2e/
+/reports/docker-clean-boot/
 /test-results/
 /web/test-results/
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -2,9 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+ARG APP_BUILD_SHA=unknown
 ENV PYTHONPATH=/app \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_PROJECT_ENVIRONMENT=/opt/cff-api-venv
+    UV_PROJECT_ENVIRONMENT=/opt/cff-api-venv \
+    APP_BUILD_SHA=${APP_BUILD_SHA}
 
 RUN pip install --no-cache-dir uv
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -2,10 +2,12 @@ FROM node:20
 
 WORKDIR /app/web
 
+ARG VITE_BUILD_SHA=unknown
 COPY web/package.json web/package-lock.json ./
 RUN npm install --global npm@10.9.3
 RUN npm ci
 
 COPY web ./
 
-ENV VITE_API_BASE_URL=/api
+ENV VITE_API_BASE_URL=/api \
+    VITE_BUILD_SHA=${VITE_BUILD_SHA}

--- a/api/app/api/routes/health.py
+++ b/api/app/api/routes/health.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
+from collegefootballfantasy_api.app.core.config import settings
 from collegefootballfantasy_api.app.db.session import get_db
+from collegefootballfantasy_api.app.schemas.runtime import RuntimeDiagnosticsRead
 from collegefootballfantasy_api.app.services.readiness import check_alembic_readiness
 
 router = APIRouter()
@@ -19,3 +21,22 @@ def readiness_check(db: Session = Depends(get_db)):
     if readiness["status"] != "ready":
         return JSONResponse(status_code=503, content=readiness)
     return readiness
+
+
+@router.get("/health/runtime", response_model=RuntimeDiagnosticsRead)
+def runtime_diagnostics(db: Session = Depends(get_db)):
+    """Expose deployment identity and migration state without leaking secrets."""
+    readiness = check_alembic_readiness(db).as_dict()
+    payload = RuntimeDiagnosticsRead(
+        status=str(readiness["status"]),
+        environment=settings.environment,
+        api_build_sha=settings.runtime_build_sha,
+        database=str(readiness["database"]),
+        migrations=str(readiness["migrations"]),
+        expected_revisions=[str(revision) for revision in readiness["expected_revisions"]],
+        current_revisions=[str(revision) for revision in readiness["current_revisions"]],
+        detail=str(readiness["detail"]),
+    )
+    if payload.status != "ready":
+        return JSONResponse(status_code=503, content=payload.model_dump())
+    return payload

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from pydantic import field_validator, model_validator
@@ -19,6 +20,7 @@ DEFAULT_CORS_ORIGIN_REGEX = r"https?://(localhost|127\.0\.0\.1):[0-9]+"
 
 class Settings(BaseSettings):
     environment: str = "development"
+    app_build_sha: str | None = None
     database_url: str = "postgresql+psycopg://postgres:postgres@localhost:5433/collegefootballfantasy"
     api_host: str = "0.0.0.0"
     api_port: int = 8000
@@ -132,6 +134,21 @@ class Settings(BaseSettings):
         return self.environment.strip().lower() == "production"
 
     @property
+    def runtime_build_sha(self) -> str:
+        """Return the deployed API artifact identifier without requiring .git at runtime."""
+        for value in (
+            self.app_build_sha,
+            os.getenv("APP_BUILD_SHA"),
+            os.getenv("VERCEL_GIT_COMMIT_SHA"),
+            os.getenv("GITHUB_SHA"),
+            os.getenv("SOURCE_VERSION"),
+        ):
+            normalized = (value or "").strip()
+            if normalized:
+                return normalized
+        return "unknown"
+
+    @property
     def allowed_cors_origins(self) -> list[str]:
         return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
 
@@ -151,6 +168,11 @@ class Settings(BaseSettings):
     def validate_production_safety(self) -> "Settings":
         if not self.is_production:
             return self
+
+        if self.runtime_build_sha == "unknown":
+            raise ValueError(
+                "APP_BUILD_SHA (or a supported deployment commit SHA) is required when ENVIRONMENT=production"
+            )
 
         if self.jwt_secret_key == DEFAULT_JWT_SECRET_KEY:
             raise ValueError("JWT_SECRET_KEY must be changed when ENVIRONMENT=production")

--- a/api/app/schemas/runtime.py
+++ b/api/app/schemas/runtime.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class RuntimeDiagnosticsRead(BaseModel):
+    """Public, non-secret identity information for diagnosing artifact mismatches."""
+
+    status: str
+    environment: str
+    api_build_sha: str
+    database: str
+    migrations: str
+    expected_revisions: list[str]
+    current_revisions: list[str]
+    detail: str

--- a/deployments.yaml
+++ b/deployments.yaml
@@ -81,6 +81,7 @@ environments:
       start_command: PYTHONPATH=. uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port ${API_PORT:-8000}
       health_path: /health
       readiness_path: /health/ready
+      runtime_diagnostics_path: /health/runtime
       minimum_replicas: 1
       restart_policy: always
       healthcheck:
@@ -99,6 +100,7 @@ environments:
       static_output: web/dist/spa
       env:
         VITE_API_BASE_URL: ${PUBLIC_API_BASE_URL}
+        VITE_BUILD_SHA: ${VITE_BUILD_SHA}
       requires_api_readiness: true
       release_check: curl --fail --show-error --silent ${PUBLIC_API_BASE_URL}/health/ready
     workers:
@@ -120,6 +122,8 @@ environments:
       - VITE_API_BASE_URL
       - REFRESH_COOKIE_SECURE
       - REFRESH_COOKIE_SAMESITE
+      - APP_BUILD_SHA
+      - VITE_BUILD_SHA
       - EMAIL_DELIVERY_MODE
       - SCORING_SEASON
       - SCORING_WEEK
@@ -143,5 +147,11 @@ environments:
       verify_alembic_head_before_promotion: true
       require_health_ready_before_traffic: true
       require_public_api_ready_before_web_promotion: true
+      require_matching_runtime_build_identity: true
       no_express_backend: true
       no_localhost_public_urls: true
+    runtime_identity_verification:
+      endpoint: ${PUBLIC_API_BASE_URL}/health/runtime
+      api_build_sha_env: APP_BUILD_SHA
+      web_build_sha_env: VITE_BUILD_SHA
+      expected_status: ready

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.api
+      args:
+        APP_BUILD_SHA: "${APP_BUILD_SHA:-local}"
     working_dir: /app
     environment:
       DATABASE_URL: postgresql+psycopg://postgres:postgres@db:5432/collegefootballfantasy
@@ -64,6 +66,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.web
+      args:
+        VITE_BUILD_SHA: "${VITE_BUILD_SHA:-local}"
     working_dir: /app/web
     ports:
       - "${WEB_PORT:-8080}:8080"

--- a/docs/release/public-beta-rc1.md
+++ b/docs/release/public-beta-rc1.md
@@ -1,0 +1,28 @@
+# Public Beta Release Candidate Gate
+
+This branch is a release candidate, not the deployment branch. Promote it to `main` only after every item below is evidenced for the exact commit being promoted.
+
+## Automated evidence
+
+- GitHub Actions **CI** is required for pull requests to `main` and pushes to `main`.
+- The required checks are `verify`, `docker-clean-boot`, and `real-stack-e2e`.
+- The workflow uploads Playwright reports, real-stack logs, and isolated-stack logs even when a job fails.
+- `/health/runtime` returns the API build SHA and Alembic readiness state. The Settings page displays the web build SHA and API build SHA together.
+
+## Required GitHub configuration
+
+Repository administrators must configure branch protection (or rulesets) for `main` to require the three CI checks above before merge. This cannot be enforced by repository code alone.
+
+## Promotion sequence
+
+1. Build API and web artifacts with the same immutable commit SHA in `APP_BUILD_SHA` and `VITE_BUILD_SHA`.
+2. Take and verify the managed-database backup.
+3. Run `alembic upgrade head` against staging, then verify `scripts/check_alembic_head.py`.
+4. Run the required CI checks and record the workflow URL and artifact links.
+5. Deploy to staging and verify `/health/runtime` reports the intended SHA and `status: ready`.
+6. Run the documented beta smoke flows against staging before merging the exact release-candidate commit to `main`.
+7. Tag the promoted commit, deploy it, and repeat the runtime identity check in production.
+
+## Rollback
+
+Rollback the web and API to the prior tagged artifact only after confirming the database migration is backward compatible. If it is not, restore from the verified pre-migration backup using the provider's documented procedure.

--- a/scripts/run_real_stack_e2e.sh
+++ b/scripts/run_real_stack_e2e.sh
@@ -8,9 +8,17 @@ export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-cff_real_e2e}"
 export DB_PORT="${DB_PORT:-55460}"
 export API_PORT="${API_PORT:-55461}"
 export WEB_PORT="${WEB_PORT:-55462}"
+REPORT_DIR="${REAL_STACK_E2E_REPORT_DIR:-$ROOT_DIR/reports/real-stack-e2e}"
+E2E_CONTAINER_NAME="${COMPOSE_PROJECT_NAME}_e2e_artifacts"
+
+mkdir -p "$REPORT_DIR"
 
 cleanup() {
+  local exit_status=$?
+  docker compose logs --no-color >"$REPORT_DIR/stack.log" 2>&1 || true
+  docker rm -f "$E2E_CONTAINER_NAME" >/dev/null 2>&1 || true
   docker compose down -v --remove-orphans
+  return "$exit_status"
 }
 trap cleanup EXIT
 
@@ -39,4 +47,14 @@ done
 docker compose exec -T db psql -U postgres -d collegefootballfantasy -Atc \
   "select status from worker_heartbeats where worker_name = 'lifecycle_processor'" | grep -qx "healthy"
 
-docker compose --profile e2e run --rm --no-deps e2e
+set +e
+docker compose --profile e2e run --no-deps --name "$E2E_CONTAINER_NAME" e2e
+e2e_status=$?
+set -e
+
+docker logs "$E2E_CONTAINER_NAME" >"$REPORT_DIR/e2e.log" 2>&1 || true
+docker cp "$E2E_CONTAINER_NAME:/app/web/playwright-report/." "$REPORT_DIR/playwright-report" 2>/dev/null || true
+docker cp "$E2E_CONTAINER_NAME:/app/web/test-results/." "$REPORT_DIR/test-results" 2>/dev/null || true
+docker rm -f "$E2E_CONTAINER_NAME" >/dev/null 2>&1 || true
+
+exit "$e2e_status"

--- a/scripts/stress_lifecycle_workers.py
+++ b/scripts/stress_lifecycle_workers.py
@@ -32,6 +32,7 @@ from collegefootballfantasy_api.app.models.trade_offer import TradeOffer
 from collegefootballfantasy_api.app.models.trade_offer_item import TradeOfferItem
 from collegefootballfantasy_api.app.models.user import User
 from collegefootballfantasy_api.app.models.waiver_claim import WaiverClaim
+from collegefootballfantasy_api.app.models.waiver_period import WaiverPeriod
 from collegefootballfantasy_api.app.models.waiver_priority import WaiverPriority
 from collegefootballfantasy_api.app.schemas.trade import TradeActionRequest
 from collegefootballfantasy_api.app.services.draft_service import process_expired_draft_picks_once
@@ -146,6 +147,40 @@ def _seed_due_work() -> dict[str, int | datetime]:
                 ),
             ]
         )
+        # Waivers only run after a completed official draft. Keep that valid
+        # lifecycle state separate from the deliberately expired draft below,
+        # which exercises the auto-pick worker in the same stress run.
+        official_draft = Draft(
+            league_id=league.id,
+            draft_datetime_utc=process_at - timedelta(days=1),
+            pick_timer_seconds=1,
+            status="completed",
+            completed_at=process_at - timedelta(hours=1),
+        )
+        db.add(official_draft)
+        db.flush()
+        db.add_all(
+            [
+                DraftPick(
+                    draft_id=official_draft.id,
+                    team_id=proposing_team.id,
+                    player_id=giving_player.id,
+                    made_by_user_id=proposing_user.id,
+                    round_number=1,
+                    round_pick=1,
+                    overall_pick=1,
+                ),
+                DraftPick(
+                    draft_id=official_draft.id,
+                    team_id=receiving_team.id,
+                    player_id=receiving_player.id,
+                    made_by_user_id=receiving_user.id,
+                    round_number=1,
+                    round_pick=2,
+                    overall_pick=2,
+                ),
+            ]
+        )
         trade = TradeOffer(
             league_id=league.id,
             proposing_team_id=proposing_team.id,
@@ -182,6 +217,18 @@ def _seed_due_work() -> dict[str, int | datetime]:
             .one()
         )
         db.delete(stale_entry)
+        waiver_period = WaiverPeriod(
+            league_id=league.id,
+            season=league.season_year,
+            week=1,
+            window_key=f"stress-{suffix}",
+            opens_at=process_at - timedelta(days=1),
+            closes_at=process_at - timedelta(minutes=1),
+            processes_at=process_at - timedelta(minutes=1),
+            status="open",
+        )
+        db.add(waiver_period)
+        db.flush()
         db.add(
             WaiverClaim(
                 league_id=league.id,
@@ -189,6 +236,10 @@ def _seed_due_work() -> dict[str, int | datetime]:
                 add_player_id=waiver_player.id,
                 created_by_user_id=proposing_user.id,
                 status="pending",
+                season=league.season_year,
+                processing_week=waiver_period.week,
+                processing_window_id=waiver_period.window_key,
+                waiver_period_id=waiver_period.id,
                 priority_snapshot=1,
                 faab_bid=7,
                 process_after=process_at - timedelta(minutes=1),

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -13,6 +13,7 @@ def make_settings(**overrides):
     defaults = {
         "_env_file": None,
         "environment": "development",
+        "app_build_sha": "test-build-sha",
         "jwt_secret_key": DEFAULT_JWT_SECRET_KEY,
         "cors_origins": DEFAULT_CORS_ORIGINS,
         "cors_origin_regex": DEFAULT_CORS_ORIGIN_REGEX,
@@ -23,6 +24,7 @@ def make_settings(**overrides):
 
 def production_required_settings() -> dict[str, object]:
     return {
+        "app_build_sha": "release-test-sha",
         "email_delivery_mode": "smtp",
         "smtp_host": "smtp.example.com",
         "smtp_from_email": "no-reply@example.com",
@@ -47,6 +49,23 @@ def test_production_rejects_default_jwt_secret():
             environment="production",
             cors_origins="https://app.example.com",
             cors_origin_regex=None,
+        )
+
+
+def test_production_rejects_missing_build_identity():
+    with pytest.raises(ValidationError, match="APP_BUILD_SHA"):
+        make_settings(
+            environment="production",
+            jwt_secret_key="safe-production-secret",
+            cors_origins="https://app.example.com",
+            cors_origin_regex=None,
+            refresh_cookie_secure=True,
+            app_build_sha=None,
+            **{
+                key: value
+                for key, value in production_required_settings().items()
+                if key != "app_build_sha"
+            },
         )
 
 

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -52,7 +52,10 @@ def test_production_rejects_default_jwt_secret():
         )
 
 
-def test_production_rejects_missing_build_identity():
+def test_production_rejects_missing_build_identity(monkeypatch):
+    for variable in ("APP_BUILD_SHA", "VERCEL_GIT_COMMIT_SHA", "GITHUB_SHA", "SOURCE_VERSION"):
+        monkeypatch.delenv(variable, raising=False)
+
     with pytest.raises(ValidationError, match="APP_BUILD_SHA"):
         make_settings(
             environment="production",

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -44,6 +44,22 @@ def test_readiness_returns_200_when_database_matches_alembic_head(client, db_ses
     assert payload["expected_revisions"] == [head]
 
 
+def test_runtime_diagnostics_exposes_build_identity_and_migration_state(client, db_session, monkeypatch):
+    head = get_alembic_heads()[0]
+    _reset_alembic_version(db_session, head)
+    monkeypatch.setenv("APP_BUILD_SHA", "release-audit-sha")
+
+    response = client.get("/health/runtime")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ready"
+    assert payload["api_build_sha"] == "release-audit-sha"
+    assert payload["current_revisions"] == [head]
+    assert payload["expected_revisions"] == [head]
+    assert payload["environment"]
+
+
 def test_readiness_returns_503_when_alembic_table_missing(client, db_session):
     _reset_alembic_version(db_session)
 
@@ -55,6 +71,17 @@ def test_readiness_returns_503_when_alembic_table_missing(client, db_session):
     assert payload["database"] == "ready"
     assert payload["migrations"] == "missing"
     assert payload["current_revisions"] == []
+
+
+def test_runtime_diagnostics_returns_503_when_migrations_are_missing(client, db_session):
+    _reset_alembic_version(db_session)
+
+    response = client.get("/health/runtime")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["status"] == "not_ready"
+    assert payload["migrations"] == "missing"
 
 
 def test_readiness_returns_503_when_database_is_behind_head(client, db_session):

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -9,6 +9,7 @@ from collegefootballfantasy_api.app.services.readiness import (
     check_alembic_readiness,
     get_alembic_heads,
 )
+from collegefootballfantasy_api.app.core.config import settings
 
 
 def _reset_alembic_version(db_session, revision: str | None = None) -> None:
@@ -47,7 +48,7 @@ def test_readiness_returns_200_when_database_matches_alembic_head(client, db_ses
 def test_runtime_diagnostics_exposes_build_identity_and_migration_state(client, db_session, monkeypatch):
     head = get_alembic_heads()[0]
     _reset_alembic_version(db_session, head)
-    monkeypatch.setenv("APP_BUILD_SHA", "release-audit-sha")
+    monkeypatch.setattr(settings, "app_build_sha", "release-audit-sha")
 
     response = client.get("/health/runtime")
 

--- a/web/client/components/runtime/RuntimeDiagnosticsPanel.spec.tsx
+++ b/web/client/components/runtime/RuntimeDiagnosticsPanel.spec.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({ apiGet: vi.fn() }));
+
+vi.mock("@/lib/api", () => ({ apiGet: state.apiGet }));
+
+import { RuntimeDiagnosticsPanel } from "./RuntimeDiagnosticsPanel";
+
+afterEach(() => {
+  cleanup();
+  state.apiGet.mockReset();
+});
+
+describe("RuntimeDiagnosticsPanel", () => {
+  it("shows the API identity and migration revision returned by the runtime endpoint", async () => {
+    state.apiGet.mockResolvedValueOnce({
+      status: "ready",
+      environment: "production",
+      api_build_sha: "0123456789abcdef",
+      database: "ready",
+      migrations: "ready",
+      expected_revisions: ["0067_split_projection_fg"],
+      current_revisions: ["0067_split_projection_fg"],
+      detail: "database and Alembic revision are ready",
+    });
+
+    render(<RuntimeDiagnosticsPanel />);
+
+    await waitFor(() => expect(screen.getByText("0123456789ab")).toBeTruthy());
+    expect(screen.getByText("0067_split_projection_fg")).toBeTruthy();
+    expect(screen.getByText("production")).toBeTruthy();
+    expect(state.apiGet).toHaveBeenCalledWith("/health/runtime");
+  });
+
+  it("keeps Settings usable and explains a runtime diagnostics request failure", async () => {
+    state.apiGet.mockRejectedValueOnce(new Error("unavailable"));
+
+    render(<RuntimeDiagnosticsPanel />);
+
+    expect((await screen.findByRole("alert")).textContent).toContain("Runtime diagnostics are unavailable");
+  });
+});

--- a/web/client/components/runtime/RuntimeDiagnosticsPanel.tsx
+++ b/web/client/components/runtime/RuntimeDiagnosticsPanel.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { Activity, RefreshCw } from "lucide-react";
+
+import { apiGet } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+
+type RuntimeDiagnostics = {
+  status: string;
+  environment: string;
+  api_build_sha: string;
+  database: string;
+  migrations: string;
+  expected_revisions: string[];
+  current_revisions: string[];
+  detail: string;
+};
+
+const webBuildSha = (import.meta.env.VITE_BUILD_SHA as string | undefined) || "unknown";
+
+const displaySha = (sha: string) => (sha === "unknown" ? sha : sha.slice(0, 12));
+
+export function RuntimeDiagnosticsPanel() {
+  const [runtime, setRuntime] = useState<RuntimeDiagnostics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadRuntime = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await apiGet<RuntimeDiagnostics>("/health/runtime");
+      setRuntime(payload);
+    } catch {
+      setRuntime(null);
+      setError("Runtime diagnostics are unavailable. Confirm the deployed web and API builds match.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadRuntime();
+  }, []);
+
+  return (
+    <section className="rounded-[2.5rem] border border-sky-300/20 bg-card/40 p-8 shadow-[0_20px_50px_rgba(0,0,0,0.3)] sm:p-10">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-4">
+          <div className="rounded-2xl bg-sky-400/10 p-3 text-sky-200">
+            <Activity className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div>
+            <h2 className="text-[10px] font-black uppercase tracking-[0.3em] text-sky-200">Runtime Diagnostics</h2>
+            <p className="mt-1 text-xs text-muted-foreground">Verify that the web app and API are on the intended release.</p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="rounded-xl text-[10px] font-black uppercase tracking-[0.16em]"
+          onClick={() => void loadRuntime()}
+          disabled={loading}
+        >
+          <RefreshCw className={loading ? "mr-2 h-3.5 w-3.5 animate-spin" : "mr-2 h-3.5 w-3.5"} />
+          Refresh
+        </Button>
+      </div>
+
+      {error ? <p role="alert" className="mt-6 text-sm font-semibold text-amber-200">{error}</p> : null}
+
+      <dl className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4" aria-busy={loading}>
+        <Diagnostic label="Web SHA" value={displaySha(webBuildSha)} />
+        <Diagnostic label="API SHA" value={runtime ? displaySha(runtime.api_build_sha) : loading ? "Loading…" : "Unavailable"} />
+        <Diagnostic
+          label="Migration"
+          value={runtime ? runtime.current_revisions.join(", ") || "Missing" : loading ? "Loading…" : "Unavailable"}
+        />
+        <Diagnostic label="Environment" value={runtime?.environment ?? (loading ? "Loading…" : "Unavailable")} />
+      </dl>
+
+      {runtime ? (
+        <p className="mt-5 text-[11px] font-semibold text-muted-foreground">
+          API status: <span className="text-foreground">{runtime.status}</span> · database: <span className="text-foreground">{runtime.database}</span> · migrations: <span className="text-foreground">{runtime.migrations}</span>
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function Diagnostic({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/35 px-4 py-4">
+      <dt className="text-[9px] font-black uppercase tracking-[0.2em] text-muted-foreground">{label}</dt>
+      <dd className="mt-2 break-all font-mono text-xs font-bold text-foreground">{value}</dd>
+    </div>
+  );
+}

--- a/web/client/pages/Settings.tsx
+++ b/web/client/pages/Settings.tsx
@@ -21,6 +21,7 @@ import { restartGuide } from "@/lib/onboarding";
 import { useLeagues } from "@/hooks/use-leagues";
 import { useActiveLeagueId } from "@/hooks/use-active-league";
 import { PasswordChangeForm } from "@/components/auth/PasswordChangeForm";
+import { RuntimeDiagnosticsPanel } from "@/components/runtime/RuntimeDiagnosticsPanel";
 
 type LeagueNotificationPreference = {
   league_id: number;
@@ -309,6 +310,7 @@ export default function Settings() {
             ) : null}
           </div>
         </SettingsSection>
+        <RuntimeDiagnosticsPanel />
       </div>
     );
   }
@@ -357,6 +359,8 @@ export default function Settings() {
             </div>
           </div>
         </SettingsSection>
+
+        <RuntimeDiagnosticsPanel />
 
         {/* NOTIFICATIONS SECTION */}
         <SettingsSection 

--- a/web/tests/e2e/core-workflows.spec.ts
+++ b/web/tests/e2e/core-workflows.spec.ts
@@ -412,7 +412,7 @@ test.describe("critical browser workflows", () => {
     });
 
     await page.goto("/leagues/create");
-    await expect(page.getByRole("heading", { name: /Create League/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Build your league/i })).toBeVisible();
     await page.getByRole("button", { name: /^Continue to /i }).click();
     await page.getByRole("button", { name: /^Continue to /i }).click();
     await page.getByRole("button", { name: /^Continue to /i }).click();
@@ -1611,6 +1611,7 @@ test.describe("critical browser workflows", () => {
       team_id: 11,
       add_player_id: 901,
       faab_bid: 0,
+      preference_order: 1,
     });
     expect(addDropCalls).toEqual([]);
   });

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,6 +5,7 @@ import path from "path";
 const apiProxyTarget = process.env.VITE_API_PROXY_TARGET ?? "http://api:8000";
 const configuredDevPort = Number(process.env.WEB_PORT ?? "8080");
 const devServerPort = Number.isInteger(configuredDevPort) && configuredDevPort > 0 ? configuredDevPort : 8080;
+const buildSha = process.env.VITE_BUILD_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA ?? "unknown";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -27,6 +28,9 @@ export default defineConfig(({ mode }) => ({
   },
   build: {
     outDir: "dist/spa",
+  },
+  define: {
+    "import.meta.env.VITE_BUILD_SHA": JSON.stringify(buildSha),
   },
   plugins: [react()],
   resolve: {


### PR DESCRIPTION
## Summary

- add immutable API/web build identity and a non-secret `/health/runtime` diagnostics contract
- display the deployed web SHA, API SHA, migration revision, and environment in Settings
- make production fail closed when no build identity is supplied
- retain Docker, Playwright, and real-stack E2E failure artifacts in CI
- document release promotion, branch-protection, backup, and rollback gates

## Root cause

The audited release path had no user-visible artifact identity, so a stale API/web channel could look like a product regression. CI also did not preserve enough runtime evidence after a failure.

## Validation

- `PYTHONPATH=. uv run pytest -q tests`
- `npm --prefix web test` — 130 passed
- `npm --prefix web run typecheck`
- `VITE_BUILD_SHA=build-identity-proof npm --prefix web run build`
- clean Docker boot verified `/health/runtime` directly and through `/api` with matching SHA and Alembic head `0067_split_projection_fg`
- real-stack Playwright E2E: 2 passed, including two-manager timeout auto-pick synchronization

## External release gates

Before merge/promotion: require CI checks in GitHub branch protection, verify a managed-database backup, migrate and smoke-test staging, then verify `/health/runtime` on the deployed artifact.