### PR TITLE
fix(web): route Vercel SPA requests to index

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds the Vercel SPA catch-all rewrite so direct navigation and hard refreshes serve Vite index.html, then resolve through React Router.

## Root cause
Vercel had no rewrite for client-side routes, so non-root requests could resolve as static-file 404s.

## Validation
- Frontend TypeScript checks passed.
- Frontend Vitest: 193 passed.
- Production Vite build passed.
- The rewrite configuration assertion passed: /(.*) routes to /index.html.

After merge, validate HTTPS direct navigation and hard refresh for /login?flow=beta and another React Router route on Vercel production.