### PR TITLE
fix(pick6): restore safe navigation and scheduled state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ HISTORICAL_STATS_PROVIDER=espn
 PLAYER_HEADSHOTS_ENABLED=false
 # Keep all Saturday Pick 6 sponsor branding, logos, and discount-code fields
 # hidden for the public beta while preserving the nullable database schema.
+SATURDAY_PICK_6_ENABLED=false
+SATURDAY_PICK_6_PUBLIC_ENABLED=false
 SATURDAY_PICK_6_SPONSORS_ENABLED=false
 # Allows manual local ESPN history imports. This does not start a scraper automatically.
 ESPN_HISTORICAL_STATS_ENABLED=true

--- a/api/app/api/routes/saturday_pick.py
+++ b/api/app/api/routes/saturday_pick.py
@@ -34,6 +34,7 @@ from collegefootballfantasy_api.app.services.content_moderation import moderate_
 
 router = APIRouter()
 admin_router = APIRouter()
+PUBLIC_CONTEST_STATUSES = ("SCHEDULED", "OPEN", "LOCKED", "SCORING", "PROVISIONAL", "FINAL")
 
 
 def _require_public_enabled() -> None:
@@ -61,7 +62,7 @@ def get_current_contest(
         .filter(
             SaturdayPickContest.season == season,
             SaturdayPickContest.week_number == week,
-            SaturdayPickContest.status.in_(("OPEN", "LOCKED", "SCORING", "PROVISIONAL", "FINAL")),
+            SaturdayPickContest.status.in_(PUBLIC_CONTEST_STATUSES),
         )
         .one_or_none()
     )

--- a/api/app/services/saturday_pick_service.py
+++ b/api/app/services/saturday_pick_service.py
@@ -161,7 +161,9 @@ def create_contest(db: Session, payload: SaturdayPickContestCreate, actor: User)
         week_number=payload.week_number,
         title=payload.title.strip() or "Saturday Pick 6",
         contest_position=payload.contest_position,
-        status="DRAFT",
+        # A scheduled contest can be shown as coming soon but cannot accept
+        # picks until publication proves all six weekly projections exist.
+        status="SCHEDULED",
         lock_at=lock_at,
         scoring_policy_version=payload.scoring_policy_version.strip() or "STANDARD_V1",
         sponsor_name=payload.sponsor_name,
@@ -207,6 +209,15 @@ def publish_contest(db: Session, contest: SaturdayPickContest) -> SaturdayPickCo
     first_kickoff = min(as_utc(player.game_time) for player in players)
     if as_utc(contest.lock_at) != first_kickoff:
         raise ValueError("Saturday Pick 6 locks exactly at the first featured player's kickoff.")
+    missing_projection_player_ids: list[int] = []
+    for featured in players:
+        projection = _weekly_projection(db, featured.player_id, contest.season, contest.week_number)
+        if projection is None:
+            missing_projection_player_ids.append(featured.player_id)
+            continue
+        featured.projected_points = projection
+    if missing_projection_player_ids:
+        raise ValueError("Publication requires verified weekly projections for all six featured players.")
     contest.status = "OPEN" if utc_now() < as_utc(contest.lock_at) else "LOCKED"
     contest.published_at = utc_now()
     contest.locked_at = utc_now() if contest.status == "LOCKED" else None

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -12,5 +12,6 @@ These checklists track implementation and acceptance gates for the open producti
 - `issue-11-checklist.md` Persistent roster actions, waivers, watchlists
 - `beta-2026-rc-validation.md` Consolidated beta release-candidate evidence and production promotion gates
 - `beta-2026-branch-inventory.md` Branch ancestry classification for the beta release candidate
+- `saturday-pick-6.md` Production enablement and weekly-projection gate for Saturday Pick 6
 
 Each file should be updated alongside implementation PRs.

--- a/docs/release/saturday-pick-6.md
+++ b/docs/release/saturday-pick-6.md
@@ -1,0 +1,21 @@
+# Saturday Pick 6 production enablement
+
+Keep all three flags disabled until an administrator has created a valid Week
+contest and its six featured players have verified kickoff times and published
+weekly projections:
+
+```dotenv
+SATURDAY_PICK_6_ENABLED=true
+SATURDAY_PICK_6_PUBLIC_ENABLED=true
+SATURDAY_PICK_6_SPONSORS_ENABLED=false
+```
+
+Set `SATURDAY_PICK_6_SPONSORS_ENABLED=true` only after sponsor branding, offer
+text, disclosure, and reward fulfillment are approved. The API never returns a
+sponsor discount code unless the contest is final and the requesting user has a
+winning entry.
+
+Creating a contest produces a `SCHEDULED` state. It may be visible as coming
+soon but cannot be published or accept picks until all six featured players
+have canonical published weekly projections. This intentionally does not derive
+weekly figures from season projections.

--- a/tests/api/test_saturday_pick_6.py
+++ b/tests/api/test_saturday_pick_6.py
@@ -8,6 +8,7 @@ from collegefootballfantasy_api.app.models.player import Player
 from collegefootballfantasy_api.app.models.player_game_stat import PlayerGameStat
 from collegefootballfantasy_api.app.models.saturday_pick import SaturdayPickContest, SaturdayPickPlayer
 from collegefootballfantasy_api.app.models.team_schedule import TeamSchedule
+from collegefootballfantasy_api.app.models.weekly_projection import WeeklyProjection
 
 
 def _enable_pick_6(monkeypatch, *, sponsors=False):
@@ -16,7 +17,7 @@ def _enable_pick_6(monkeypatch, *, sponsors=False):
     monkeypatch.setattr(settings, "saturday_pick_6_sponsors_enabled", sponsors)
 
 
-def _featured_players(db_session, *, position="QB", final_games=False):
+def _featured_players(db_session, *, position="QB", final_games=False, with_weekly_projections=True):
     kickoff = datetime.now(timezone.utc) + timedelta(hours=4)
     players = []
     for index in range(6):
@@ -44,6 +45,15 @@ def _featured_players(db_session, *, position="QB", final_games=False):
             is_bye=False,
             kickoff_at=game.start_date,
         ))
+        if with_weekly_projections:
+            db_session.add(WeeklyProjection(
+                player_id=player.id,
+                season=2026,
+                week=1,
+                is_published=True,
+                projection_version="FINAL",
+                fantasy_points=18.0 + index,
+            ))
         if final_games:
             db_session.add(PlayerGameStat(
                 player_id=player.id,
@@ -117,6 +127,26 @@ def test_contest_lock_is_the_first_featured_player_kickoff_and_identifies_that_p
     published = client.post(f"/admin/saturday-pick-6/{payload['id']}/publish", json={}, headers=headers)
     assert published.status_code == 200
     assert datetime.fromisoformat(published.json()["lock_at"].replace("Z", "+00:00")).replace(tzinfo=timezone.utc) == kickoff
+
+
+def test_scheduled_contest_is_visible_but_cannot_open_without_six_verified_weekly_projections(client, db_session, monkeypatch):
+    _enable_pick_6(monkeypatch)
+    players, kickoff = _featured_players(db_session, with_weekly_projections=False)
+    headers = admin_headers(client)
+    created = client.post("/admin/saturday-pick-6", json=_create_payload(players, kickoff), headers=headers)
+    assert created.status_code == 201
+    assert created.json()["status"] == "SCHEDULED"
+    assert all(player["projected_points"] is None for player in created.json()["players"])
+
+    signup = client.post("/auth/signup", json={"first_name": "Scheduled", "email": "scheduled@example.com", "password": "StrongPass123!"})
+    user_headers = {"Authorization": f"Bearer {signup.json()['access_token']}"}
+    current = client.get("/saturday-pick-6/current", params={"season": 2026, "week": 1}, headers=user_headers)
+    assert current.status_code == 200
+    assert current.json()["status"] == "SCHEDULED"
+
+    published = client.post(f"/admin/saturday-pick-6/{created.json()['id']}/publish", json={}, headers=headers)
+    assert published.status_code == 422
+    assert "verified weekly projections" in published.json()["detail"]
 
 
 def test_saturday_pick_hides_featured_player_headshots_for_public_beta(client, db_session):

--- a/web/client/components/AppOnboardingTour.tsx
+++ b/web/client/components/AppOnboardingTour.tsx
@@ -23,6 +23,12 @@ export const TOUR_STEPS: TourStep[] = [
       "Use Leagues to create, join, and manage your fantasy leagues, view league settings, and prepare for your draft.",
   },
   {
+    target: "#nav-saturday-pick-6",
+    title: "Saturday Pick 6",
+    description:
+      "Saturday Pick 6 is your weekly featured-player challenge. Picks will open here once the approved weekly contest is ready.",
+  },
+  {
     target: "#nav-chats",
     title: "Chats",
     description:

--- a/web/client/components/app-shell/navigation.spec.ts
+++ b/web/client/components/app-shell/navigation.spec.ts
@@ -69,6 +69,12 @@ describe("app shell navigation helpers", () => {
     );
   });
 
+  it("includes Saturday Pick 6 in authenticated desktop navigation", () => {
+    expect(getShellNavItems(user, true)).toContainEqual(
+      expect.objectContaining({ name: "SATURDAY PICK 6", path: "/saturday-pick-6" }),
+    );
+  });
+
   it("surfaces an unread badge for the chats sidebar item", () => {
     const chats = getShellNavItems(user, true, 12).find((item) => item.name === "CHATS");
     const cappedChats = getShellNavItems(user, true, 120).find((item) => item.name === "CHATS");
@@ -81,9 +87,11 @@ describe("app shell navigation helpers", () => {
     const mobileItems = getMobileNavItems(getShellNavItems(user, true, 1, true));
     const mobile = mobileItems.map((item) => item.name);
 
-    expect(mobile).toEqual(["HOME", "LEAGUES", "CHATS", "REPORT BUG", "MOCK DRAFT"]);
+    expect(mobile).toEqual(["HOME", "LEAGUES", "SATURDAY PICK 6", "CHATS", "MOCK DRAFT"]);
+    expect(mobile).toHaveLength(5);
     expect(mobileItems.find((item) => item.name === "CHATS")?.badge).toBe("1");
     expect(mobile).not.toContain("SIGN OUT");
+    expect(mobile).not.toContain("REPORT BUG");
   });
 
   it("preserves stable onboarding target IDs", () => {

--- a/web/client/components/app-shell/navigation.ts
+++ b/web/client/components/app-shell/navigation.ts
@@ -54,6 +54,7 @@ export const getShellNavItems = (
   return [
     { name: "HOME", path: "/", icon: Home },
     { name: "LEAGUES", path: "/leagues", icon: Trophy },
+    { name: "SATURDAY PICK 6", path: "/saturday-pick-6", icon: Trophy },
     {
       name: "CHATS",
       path: "/chats",
@@ -76,14 +77,16 @@ export const getShellNavItems = (
 };
 
 export const getMobileNavItems = (items: ShellNavItem[]) => {
-  // The mobile bar is limited to five destinations. Keep bug reporting in
-  // that primary set so the Report Bug action is not desktop-only.
-  const preferred = new Set(["HOME", "LEAGUES", "CHATS", "MOCK DRAFT", "REPORT BUG"]);
-  const filtered = items.filter((item) => preferred.has(item.name));
+  // The mobile bar is limited to five destinations. Saturday Pick 6 replaces
+  // the lower-priority Report Bug shortcut; that action remains on desktop.
+  const preferred = ["HOME", "LEAGUES", "SATURDAY PICK 6", "CHATS", "MOCK DRAFT"];
+  const byName = new Map(items.map((item) => [item.name, item]));
+  const filtered = preferred.flatMap((name) => {
+    const item = byName.get(name);
+    return item ? [item] : [];
+  });
 
-  if (filtered.length >= 4) {
-    return filtered.slice(0, 5);
-  }
+  if (filtered.length >= 4) return filtered;
 
   return items.filter((item) => item.kind !== "danger" && item.kind !== "admin").slice(0, 5);
 };

--- a/web/client/pages/SaturdayPick6.render.spec.tsx
+++ b/web/client/pages/SaturdayPick6.render.spec.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const contestQuery = vi.hoisted(() => ({
+  data: undefined as unknown,
+  isLoading: false,
+  isError: true,
+  refetch: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-saturday-pick", () => ({
+  useSaturdayPickContest: () => contestQuery,
+  useSaveSaturdayPick: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import SaturdayPick6, { SATURDAY_PICK_6_COMING_SOON_MESSAGE } from "./SaturdayPick6";
+
+describe("SaturdayPick6 unavailable states", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    contestQuery.data = undefined;
+    contestQuery.isLoading = false;
+    contestQuery.isError = true;
+  });
+
+  it("keeps the direct route polished when the contest API is disabled or returns 404", () => {
+    render(<MemoryRouter initialEntries={["/saturday-pick-6"]}><SaturdayPick6 /></MemoryRouter>);
+
+    expect(screen.getByRole("heading", { name: "Saturday Pick 6" })).toBeTruthy();
+    expect(screen.getByText(SATURDAY_PICK_6_COMING_SOON_MESSAGE)).toBeTruthy();
+    expect(screen.queryByText(/West Georgia Cornhole/i)).toBeNull();
+  });
+
+  it("keeps an empty published response in the coming-soon state", () => {
+    contestQuery.data = { status: "OPEN", players: [] };
+    render(<MemoryRouter><SaturdayPick6 embedded /></MemoryRouter>);
+
+    expect(screen.getByText(SATURDAY_PICK_6_COMING_SOON_MESSAGE)).toBeTruthy();
+  });
+});

--- a/web/client/pages/SaturdayPick6.spec.tsx
+++ b/web/client/pages/SaturdayPick6.spec.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { SaturdayPickPlayer } from "@/hooks/use-saturday-pick";
 import { getSaturdayPickRewardMessage, getSaturdayPickSponsorLogo } from "@/lib/saturday-pick-sponsor";
 
-import { displayPoints, lockDeadlineMessage, pickConfirmationMessage, positionLabel, shouldRevealSponsorReward, statusLabel } from "./SaturdayPick6";
+import { displayPoints, isSaturdayPick6ComingSoon, lockDeadlineMessage, pickConfirmationMessage, positionLabel, SATURDAY_PICK_6_COMING_SOON_MESSAGE, shouldRevealSponsorReward, statusLabel } from "./SaturdayPick6";
 
 const player: SaturdayPickPlayer = {
   id: 1,
@@ -49,6 +49,16 @@ describe("SaturdayPick6 state helpers", () => {
     expect(shouldRevealSponsorReward("FINAL", { is_winner: false })).toBe(false);
     expect(shouldRevealSponsorReward("FINAL", null)).toBe(false);
     expect(shouldRevealSponsorReward("FINAL", { is_winner: true })).toBe(true);
+  });
+
+  it("keeps disabled, empty, and scheduled contests in the polished coming-soon state", () => {
+    expect(isSaturdayPick6ComingSoon(undefined)).toBe(true);
+    expect(isSaturdayPick6ComingSoon({ status: "OPEN", players: [] })).toBe(true);
+    expect(isSaturdayPick6ComingSoon({ status: "SCHEDULED", players: [player] })).toBe(true);
+    expect(isSaturdayPick6ComingSoon({ status: "OPEN", players: [player] })).toBe(false);
+    expect(SATURDAY_PICK_6_COMING_SOON_MESSAGE).toBe(
+      "Week 1 picks are coming soon. Six featured players will be available once weekly projections are published.",
+    );
   });
 
   it("uses only the sponsor logo supplied by the API", () => {

--- a/web/client/pages/SaturdayPick6.tsx
+++ b/web/client/pages/SaturdayPick6.tsx
@@ -5,7 +5,10 @@ import { Check, CircleX, Clock3, Copy, Lock, Radio, Trophy, UserRound } from "lu
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { type SaturdayPickPlayer, useSaveSaturdayPick, useSaturdayPickContest } from "@/hooks/use-saturday-pick";
-import { getSaturdayPickSponsorLogo, saturdayPick6Sponsor } from "@/lib/saturday-pick-sponsor";
+import { getSaturdayPickSponsorLogo } from "@/lib/saturday-pick-sponsor";
+
+export const SATURDAY_PICK_6_COMING_SOON_MESSAGE =
+  "Week 1 picks are coming soon. Six featured players will be available once weekly projections are published.";
 
 const formatPoints = (value: number | null) =>
   typeof value === "number" && Number.isFinite(value) ? value.toFixed(1) : "—";
@@ -49,6 +52,13 @@ export const shouldRevealSponsorReward = (
   entry: { is_winner: boolean } | null | undefined,
 ) => contestStatus === "FINAL" && entry?.is_winner === true;
 
+export const isSaturdayPick6ComingSoon = (
+  contest: { status: string; players: SaturdayPickPlayer[] } | null | undefined,
+) =>
+  !contest ||
+  contest.players.length === 0 ||
+  ["DRAFT", "SCHEDULED", "COMING_SOON"].includes(contest.status);
+
 function useCountdown(lockAt: string | undefined) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -68,6 +78,17 @@ function useCountdown(lockAt: string | undefined) {
 type SaturdayPick6Props = {
   embedded?: boolean;
 };
+
+function SaturdayPick6ComingSoon({ embedded }: SaturdayPick6Props) {
+  return (
+    <section className={embedded ? "rounded-3xl border border-cfb-border-subtle bg-cfb-surface p-6 text-center" : "mx-auto max-w-4xl py-20 text-center"}>
+      <p className="cfb-micro-label text-cfb-brand">Saturday Pick 6</p>
+      <h1 className="mt-3 text-4xl font-black text-cfb-text-primary">Saturday Pick 6</h1>
+      <p className="mx-auto mt-4 max-w-xl text-cfb-text-secondary">{SATURDAY_PICK_6_COMING_SOON_MESSAGE}</p>
+      {!embedded ? <Button asChild className="mt-7"><Link to="/">Back to dashboard</Link></Button> : null}
+    </section>
+  );
+}
 
 export default function SaturdayPick6({ embedded = false }: SaturdayPick6Props) {
   const contestQuery = useSaturdayPickContest();
@@ -104,16 +125,9 @@ export default function SaturdayPick6({ embedded = false }: SaturdayPick6Props) 
   if (contestQuery.isLoading) {
     return <div className="mx-auto max-w-7xl py-20 text-center text-sm font-black uppercase tracking-[0.2em] text-cfb-text-muted">Loading Saturday Pick 6…</div>;
   }
-  if (!contest) {
-    return (
-      <div className="mx-auto max-w-4xl py-20 text-center">
-        <p className="cfb-micro-label text-cfb-brand">Saturday Pick 6</p>
-        <h1 className="mt-3 text-4xl font-black text-cfb-text-primary">Coming next week</h1>
-        <p className="mx-auto mt-4 max-w-xl text-cfb-text-secondary">Six featured players. One weekly prediction. One prize.</p>
-        <Button asChild className="mt-7"><Link to="/">Back to dashboard</Link></Button>
-      </div>
-    );
-  }
+  // A disabled feature, 404 response, unpublished schedule, or empty slate
+  // is non-actionable. Keep both route and dashboard card stable.
+  if (isSaturdayPick6ComingSoon(contest)) return <SaturdayPick6ComingSoon embedded={embedded} />;
 
   const selectedPlayer = contest.players.find((player) => player.id === selectedPickId) ?? null;
   const savedPlayer = contest.players.find((player) => player.id === contest.entry?.selected_pick_player_id) ?? null;
@@ -121,20 +135,12 @@ export default function SaturdayPick6({ embedded = false }: SaturdayPick6Props) 
     (left, right) => new Date(left.game_time).getTime() - new Date(right.game_time).getTime() || left.sort_order - right.sort_order
   )[0];
   const lockPlayerName = firstGamePlayer?.player_name ?? "the first featured player";
-  // Branding is allowed before the challenge starts. The reward itself is
-  // deliberately API-owned: the code is never present in the client fallback
-  // and is only returned for a finalized, winning entry.
-  const sponsor = contest.sponsor ?? {
-    name: saturdayPick6Sponsor.name,
-    logo_url: saturdayPick6Sponsor.logo_url,
-    offer_text: null,
-    terms: null,
-    reward_unlocked: false,
-    code: null,
-    url: null,
-  };
+  // Sponsor data remains API-owned and is absent until the server has an
+  // approved sponsor configuration. No browser fallback may expose branding
+  // or a reward code.
+  const sponsor = contest.sponsor;
   const sponsorLogo = getSaturdayPickSponsorLogo(sponsor);
-  const revealSponsorReward = shouldRevealSponsorReward(contest.status, contest.entry);
+  const revealSponsorReward = Boolean(sponsor) && shouldRevealSponsorReward(contest.status, contest.entry);
   const submit = async () => {
     if (!selectedPickId || !isOpen) return;
     setSubmitError(null);
@@ -146,7 +152,7 @@ export default function SaturdayPick6({ embedded = false }: SaturdayPick6Props) 
     }
   };
   const copySponsorCode = async () => {
-    if (sponsor.code) await navigator.clipboard?.writeText(sponsor.code);
+    if (sponsor?.code) await navigator.clipboard?.writeText(sponsor.code);
   };
 
   return (
@@ -164,8 +170,10 @@ export default function SaturdayPick6({ embedded = false }: SaturdayPick6Props) 
             <p className="mt-4 max-w-2xl text-base font-bold leading-7 text-cfb-text-secondary sm:text-lg">Which featured {positionLabel(contest.contest_position)} will score the most fantasy points this week?</p>
           </div>
           <div className="flex flex-wrap items-center gap-6">
-            <div className="flex h-32 w-32 shrink-0 items-center justify-center overflow-hidden rounded-3xl border border-white/25 bg-white p-1.5 shadow-[0_0_34px_rgba(34,211,238,0.20)] sm:h-36 sm:w-36">{sponsorLogo ? <img src={sponsorLogo} alt="West Georgia Cornhole" className="h-full w-full object-contain" /> : <span className="text-sm font-black text-cfb-brand">{sponsor.name.slice(0, 2).toUpperCase()}</span>}</div>
-            <div className="max-w-md"><p className="cfb-micro-label text-cyan-200">Presented by</p><p className="mt-2 text-2xl font-black leading-tight text-white sm:text-3xl">{sponsor.name}</p><p className="mt-3 text-lg font-black leading-7 text-cyan-100 sm:text-xl">{saturdayPick6Sponsor.tagline}</p></div>
+            {sponsor ? <>
+              <div className="flex h-32 w-32 shrink-0 items-center justify-center overflow-hidden rounded-3xl border border-white/25 bg-white p-1.5 shadow-[0_0_34px_rgba(34,211,238,0.20)] sm:h-36 sm:w-36">{sponsorLogo ? <img src={sponsorLogo} alt={sponsor.name} className="h-full w-full object-contain" /> : <span className="text-sm font-black text-cfb-brand">{sponsor.name.slice(0, 2).toUpperCase()}</span>}</div>
+              <div className="max-w-md"><p className="cfb-micro-label text-cyan-200">Presented by</p><p className="mt-2 text-2xl font-black leading-tight text-white sm:text-3xl">{sponsor.name}</p>{sponsor.offer_text ? <p className="mt-3 text-lg font-black leading-7 text-cyan-100 sm:text-xl">{sponsor.offer_text}</p> : null}</div>
+            </> : null}
             <div className="flex flex-wrap items-center gap-3"><div className="rounded-2xl border border-cfb-border-strong bg-slate-950/55 px-5 py-3 text-right"><p className="cfb-micro-label text-cfb-text-muted">{isOpen ? "Locks in" : "Contest status"}</p><p className="mt-1 font-display text-2xl font-black tabular-nums text-cyan-100">{isOpen ? countdown.value : statusLabel(contest.status)}</p></div>{embedded && isOpen ? <Button asChild><Link to="/saturday-pick-6">{contest.entry ? "Change Your Pick" : "Make Your Pick"}</Link></Button> : null}</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- restores Saturday Pick 6 in authenticated desktop and mobile navigation
- keeps the route and embedded dashboard state polished when disabled, empty, scheduled, or unavailable
- removes the client-side sponsor fallback; branding and rewards remain API-authoritative
- exposes a `SCHEDULED` contest only as coming soon and blocks publication until all six canonical weekly projections are published

## Validation

- `PYTHONPATH=. uv run pytest -q tests/api/test_saturday_pick_6.py`
- `npm --prefix web test -- client/components/app-shell/navigation.spec.ts client/pages/SaturdayPick6.spec.tsx client/pages/SaturdayPick6.render.spec.tsx`
- `npm --prefix web run typecheck`
- `npm --prefix web run build`

No production variables, contests, projections, or other data were changed.
