### PR TITLE
feat(data): add controlled player enrichment pipeline

### DIFF
--- a/api/app/services/player_enrichment_import.py
+++ b/api/app/services/player_enrichment_import.py
@@ -1,0 +1,443 @@
+"""Source-gated, deterministic player-enrichment imports.
+
+This module deliberately consumes *staged exports*, never a live provider.
+Production operators must review a dry-run and verify a logical database backup
+before using an apply command.  It never changes canonical player identity,
+preseason projections, or current value ratings.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Iterable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from collegefootballfantasy_api.app.models.historical_stats import PlayerHistoricalSeasonStat
+from collegefootballfantasy_api.app.models.college_team import CollegeTeam
+from collegefootballfantasy_api.app.models.player import Player
+from collegefootballfantasy_api.app.models.player_stat import PlayerStat
+from collegefootballfantasy_api.app.models.provider_identity import PlayerProviderId
+from collegefootballfantasy_api.app.models.weekly_projection import WeeklyProjection
+from collegefootballfantasy_api.app.services.provider_identity import ProviderIdentityConflict, upsert_player_provider_mapping
+
+
+class MatchOutcome(StrEnum):
+    EXACT = "EXACT"
+    VERIFIED_ALIAS = "VERIFIED_ALIAS"
+    AMBIGUOUS = "AMBIGUOUS"
+    NOT_FOUND = "NOT_FOUND"
+    CONFLICT = "CONFLICT"
+
+
+IDENTITY_FIELDS = {
+    "provider", "provider_player_id", "provider_team_id", "provider_team_name", "player_name", "school", "position",
+}
+BIO_FIELDS = {
+    "height", "weight", "birthplace", "jersey", "player_class", "profile_status", "headshot_url", "headshot_approved",
+}
+HISTORICAL_NUMERIC_FIELDS = {
+    "games_played", "games_started", "passing_completions", "passing_attempts", "passing_yards", "passing_touchdowns",
+    "interceptions", "sacks_taken", "rushing_attempts", "rushing_yards", "rushing_touchdowns", "long_rush", "receptions",
+    "receiving_targets", "receiving_yards", "receiving_touchdowns", "long_reception", "kick_return_attempts",
+    "kick_return_yards", "kick_return_touchdowns", "punt_return_attempts", "punt_return_yards", "punt_return_touchdowns",
+    "field_goals_made", "field_goals_attempted", "field_goals_0_19", "field_goals_20_29", "field_goals_30_39",
+    "field_goals_40_49", "field_goals_50_plus", "extra_points_made", "extra_points_attempted", "kick_points",
+    "fumbles", "fumbles_lost",
+}
+WEEKLY_NUMERIC_FIELDS = {
+    "pass_attempts", "rush_attempts", "targets", "receptions", "expected_plays", "expected_rush_per_play",
+    "expected_td_per_play", "pass_yards", "rush_yards", "rec_yards", "pass_tds", "rush_tds", "rec_tds",
+    "interceptions", "field_goals_made_0_to_39", "field_goals_made_40_to_49", "field_goals_made_0_to_49",
+    "field_goals_made_50_plus", "extra_points_made", "neutral_baseline", "availability_multiplier", "usage_multiplier",
+    "offense_multiplier", "opponent_defense_multiplier", "confidence", "fantasy_points", "floor", "ceiling", "boom_prob", "bust_prob",
+}
+
+
+def normalized(value: object | None) -> str:
+    text = unicodedata.normalize("NFKD", str(value or "")).lower().replace("&", "and")
+    return "".join(character for character in text if character.isalnum())
+
+
+def text(value: object | None) -> str | None:
+    normalized_value = str(value or "").strip()
+    return normalized_value or None
+
+
+def number(value: object | None) -> float | None:
+    raw = text(value)
+    if raw is None:
+        return None
+    try:
+        return float(raw.replace(",", ""))
+    except ValueError as exc:
+        raise ValueError(f"expected numeric value, received {raw!r}") from exc
+
+
+def boolean(value: object | None) -> bool:
+    return (text(value) or "").lower() in {"1", "true", "yes", "y", "on"}
+
+
+@dataclass(frozen=True)
+class EnrichmentSourceRow:
+    row_number: int
+    values: dict[str, str]
+
+    def value(self, key: str) -> str | None:
+        return text(self.values.get(key))
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    outcome: MatchOutcome
+    player_id: int | None = None
+    detail: str | None = None
+
+
+@dataclass
+class EnrichmentReport:
+    stage: str
+    source_rows: int = 0
+    exact: int = 0
+    verified_alias: int = 0
+    ambiguous: int = 0
+    not_found: int = 0
+    conflicts: int = 0
+    ready: int = 0
+    inserted: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    manual_review: list[dict[str, Any]] = field(default_factory=list)
+
+    def add(self, result: MatchResult, row: EnrichmentSourceRow) -> None:
+        setattr(self, result.outcome.value.lower(), getattr(self, result.outcome.value.lower()) + 1)
+        if result.outcome in {MatchOutcome.EXACT, MatchOutcome.VERIFIED_ALIAS}:
+            self.ready += 1
+        else:
+            self.manual_review.append({"row_number": row.row_number, "outcome": result.outcome, "detail": result.detail})
+
+    @property
+    def has_unresolved_identity_conflicts(self) -> bool:
+        return any((self.ambiguous, self.not_found, self.conflicts))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage, "source_rows": self.source_rows, "exact": self.exact,
+            "verified_alias": self.verified_alias, "ambiguous": self.ambiguous, "not_found": self.not_found,
+            "conflicts": self.conflicts, "ready": self.ready, "inserted": self.inserted,
+            "updated": self.updated, "unchanged": self.unchanged, "manual_review": self.manual_review,
+        }
+
+
+def read_csv_rows(path: Path, *, required: Iterable[str]) -> list[EnrichmentSourceRow]:
+    with path.open(newline="", encoding="utf-8-sig") as source:
+        reader = csv.DictReader(source)
+        headers = set(reader.fieldnames or [])
+        missing = sorted(set(required) - headers)
+        if missing:
+            raise ValueError(f"{path.name} is missing required columns: {', '.join(missing)}")
+        return [EnrichmentSourceRow(index, {key: value or "" for key, value in row.items()}) for index, row in enumerate(reader, 2)]
+
+
+def read_verified_aliases(path: Path | None) -> dict[tuple[str, str], int]:
+    if path is None:
+        return {}
+    aliases = read_csv_rows(path, required={"provider", "provider_player_id", "player_id"})
+    result: dict[tuple[str, str], int] = {}
+    for alias in aliases:
+        provider, provider_id, player_id = alias.value("provider"), alias.value("provider_player_id"), alias.value("player_id")
+        if not provider or not provider_id or not player_id or not player_id.isdigit():
+            raise ValueError(f"invalid verified alias at row {alias.row_number}")
+        key = (provider.lower(), provider_id)
+        if key in result:
+            raise ValueError(f"duplicate verified alias at row {alias.row_number}")
+        result[key] = int(player_id)
+    return result
+
+
+def _compatible(player: Player, row: EnrichmentSourceRow) -> bool:
+    return (
+        normalized(player.school) == normalized(row.value("school"))
+        and (player.position or "").upper() == (row.value("position") or "").upper()
+    )
+
+
+def resolve_identity(
+    db: Session,
+    row: EnrichmentSourceRow,
+    *,
+    approved_aliases: dict[tuple[str, str], int] | None = None,
+) -> MatchResult:
+    """Resolve only a full canonical identity or an explicit reviewed alias."""
+    provider, provider_id = row.value("provider"), row.value("provider_player_id")
+    if not provider or not provider_id:
+        return MatchResult(MatchOutcome.NOT_FOUND, detail="provider and provider_player_id are required")
+    mappings = db.scalars(
+        select(PlayerProviderId).where(
+            PlayerProviderId.provider == provider.lower(), PlayerProviderId.provider_player_id == provider_id
+        )
+    ).all()
+    if len(mappings) > 1:
+        return MatchResult(MatchOutcome.CONFLICT, detail="provider ID maps to multiple canonical players")
+    if mappings:
+        player = db.get(Player, mappings[0].player_id)
+        if player and _compatible(player, row):
+            return MatchResult(MatchOutcome.EXACT, player.id, "existing verified provider mapping")
+        return MatchResult(MatchOutcome.CONFLICT, detail="provider ID identity conflicts with canonical player")
+    alias_id = (approved_aliases or {}).get((provider.lower(), provider_id))
+    if alias_id is not None:
+        player = db.get(Player, alias_id)
+        if player is None or not _compatible(player, row):
+            return MatchResult(MatchOutcome.CONFLICT, detail="verified alias does not match canonical school and position")
+        return MatchResult(MatchOutcome.VERIFIED_ALIAS, player.id, "reviewed provider ID alias")
+    candidates = db.scalars(select(Player).where(Player.name == (row.value("player_name") or ""))).all()
+    exact = [candidate for candidate in candidates if _compatible(candidate, row)]
+    if len(exact) == 1:
+        return MatchResult(MatchOutcome.EXACT, exact[0].id, "name, school, and position")
+    if len(exact) > 1:
+        return MatchResult(MatchOutcome.AMBIGUOUS, detail="multiple canonical players share the full identity")
+    if candidates:
+        return MatchResult(MatchOutcome.CONFLICT, detail="name found but canonical school or position differs")
+    return MatchResult(MatchOutcome.NOT_FOUND, detail="no canonical player has this name, school, and position")
+
+
+def _existing_player_mappings(db: Session, player_id: int, provider: str) -> PlayerProviderId | None:
+    return db.scalar(select(PlayerProviderId).where(PlayerProviderId.player_id == player_id, PlayerProviderId.provider == provider.lower()))
+
+
+def import_identities_and_bios(
+    db: Session, rows: list[EnrichmentSourceRow], *, approved_aliases: dict[tuple[str, str], int], apply: bool
+) -> EnrichmentReport:
+    report = EnrichmentReport(stage="identities")
+    for row in rows:
+        report.source_rows += 1
+        result = resolve_identity(db, row, approved_aliases=approved_aliases)
+        report.add(result, row)
+        if result.player_id is None:
+            continue
+        player = db.get(Player, result.player_id)
+        assert player is not None
+        provider, provider_id = row.value("provider"), row.value("provider_player_id")
+        assert provider and provider_id
+        existing = _existing_player_mappings(db, player.id, provider)
+        bio_values = {
+            "espn_height": row.value("height"), "espn_weight": row.value("weight"), "espn_birthplace": row.value("birthplace"),
+            "espn_jersey": row.value("jersey"), "player_class": row.value("player_class"), "espn_status": row.value("profile_status"),
+            "bio_source": provider.lower(), "espn_source_url": row.value("source_url"),
+        }
+        if boolean(row.value("headshot_approved")):
+            bio_values["espn_headshot_url"] = row.value("headshot_url")
+        changed = existing is None or any(getattr(player, key) != value for key, value in bio_values.items() if value is not None)
+        if not changed:
+            report.unchanged += 1
+            continue
+        if apply:
+            try:
+                upsert_player_provider_mapping(
+                    db, player_id=player.id, provider=provider, provider_player_id=provider_id,
+                    provider_team_id=row.value("provider_team_id"), match_confidence=1.0,
+                    verification_status="verified", reason="approved staged enrichment import",
+                )
+            except ProviderIdentityConflict as exc:
+                raise ValueError(f"identity conflict at source row {row.row_number}: {exc}") from exc
+            for key, value in bio_values.items():
+                if value is not None:
+                    setattr(player, key, value)
+            player.espn_profile_synced_at = datetime.now(timezone.utc)
+        report.updated += int(existing is not None)
+        report.inserted += int(existing is None)
+    return report
+
+
+def import_historical_totals(
+    db: Session, rows: list[EnrichmentSourceRow], *, approved_aliases: dict[tuple[str, str], int], apply: bool, source_sha256: str
+) -> EnrichmentReport:
+    report = EnrichmentReport(stage="historical")
+    for row in rows:
+        report.source_rows += 1
+        result = resolve_identity(db, row, approved_aliases=approved_aliases)
+        report.add(result, row)
+        season = row.value("season")
+        if result.player_id is None or not season or not season.isdigit():
+            if result.player_id is not None:
+                report.conflicts += 1
+                report.manual_review.append({"row_number": row.row_number, "outcome": MatchOutcome.CONFLICT, "detail": "valid season is required"})
+            continue
+        player = db.get(Player, result.player_id)
+        assert player is not None
+        provider, provider_id = row.value("provider"), row.value("provider_player_id")
+        assert provider and provider_id
+        season_number = int(season)
+        team_name = row.value("historical_team") or row.value("school")
+        existing = db.scalar(select(PlayerHistoricalSeasonStat).where(
+            PlayerHistoricalSeasonStat.player_id == player.id, PlayerHistoricalSeasonStat.provider == provider.lower(),
+            PlayerHistoricalSeasonStat.season == season_number, PlayerHistoricalSeasonStat.season_type == (row.value("season_type") or "regular"),
+            PlayerHistoricalSeasonStat.team_name == team_name,
+        ))
+        values = {field: number(row.value(field)) for field in HISTORICAL_NUMERIC_FIELDS if row.value(field) is not None}
+        if existing and all(getattr(existing, key) == value for key, value in values.items()) and existing.source_response_hash == source_sha256:
+            report.unchanged += 1
+            continue
+        if apply:
+            target = existing or PlayerHistoricalSeasonStat(
+                player_id=player.id, provider=provider.lower(), provider_player_id=provider_id, season=season_number,
+                season_type=row.value("season_type") or "regular", team_name=team_name, parser_version="staged-enrichment-v1",
+                imported_at=datetime.now(timezone.utc),
+            )
+            for key, value in values.items():
+                setattr(target, key, value)
+            target.provider_team_id = row.value("provider_team_id")
+            target.position = row.value("position")
+            target.canonical_position = player.position
+            target.source_response_hash = source_sha256
+            target.source_url = row.value("source_url")
+            target.source_type = "approved_staged_export"
+            target.import_version = f"staged-enrichment:{source_sha256[:12]}"
+            target.parser_version = "staged-enrichment-v1"
+            target.imported_at = datetime.now(timezone.utc)
+            # Do not invent fantasy totals; historical scoring is calculated only when a complete approved scoring contract exists.
+            target.fantasy_points = None
+            target.fantasy_points_per_game = None
+            target.scoring_rules_version = None
+            if existing is None:
+                db.add(target)
+        report.updated += int(existing is not None)
+        report.inserted += int(existing is None)
+    return report
+
+
+def import_completed_weekly_stats(
+    db: Session, rows: list[EnrichmentSourceRow], *, approved_aliases: dict[tuple[str, str], int], apply: bool
+) -> EnrichmentReport:
+    report = EnrichmentReport(stage="completed-stats")
+    for row in rows:
+        report.source_rows += 1
+        result = resolve_identity(db, row, approved_aliases=approved_aliases)
+        report.add(result, row)
+        season, week, stats_json = row.value("season"), row.value("week"), row.value("stats_json")
+        if result.player_id is None or not season or not season.isdigit() or not week or not week.isdigit() or not stats_json:
+            if result.player_id is not None:
+                report.conflicts += 1
+                report.manual_review.append({"row_number": row.row_number, "outcome": MatchOutcome.CONFLICT, "detail": "season, week, and stats_json are required"})
+            continue
+        try:
+            stats = json.loads(stats_json)
+        except json.JSONDecodeError:
+            report.conflicts += 1
+            report.manual_review.append({"row_number": row.row_number, "outcome": MatchOutcome.CONFLICT, "detail": "stats_json is invalid"})
+            continue
+        if not isinstance(stats, dict):
+            report.conflicts += 1
+            report.manual_review.append({"row_number": row.row_number, "outcome": MatchOutcome.CONFLICT, "detail": "stats_json must be an object"})
+            continue
+        existing = db.scalar(select(PlayerStat).where(PlayerStat.player_id == result.player_id, PlayerStat.season == int(season), PlayerStat.week == int(week)))
+        if existing and existing.stats == stats and existing.source == (row.value("provider") or "approved_staged_export"):
+            report.unchanged += 1
+            continue
+        if apply:
+            if existing is None:
+                db.add(PlayerStat(player_id=result.player_id, season=int(season), week=int(week), stats=stats, source=row.value("provider") or "approved_staged_export"))
+            else:
+                existing.stats = stats
+                existing.source = row.value("provider") or "approved_staged_export"
+                existing.verified = True
+        report.updated += int(existing is not None)
+        report.inserted += int(existing is None)
+    return report
+
+
+def import_weekly_projections(
+    db: Session, rows: list[EnrichmentSourceRow], *, approved_aliases: dict[tuple[str, str], int], apply: bool
+) -> EnrichmentReport:
+    """Import an approved week-specific projection file; never derive a week from a season total."""
+    report = EnrichmentReport(stage="weekly-projections")
+    for row in rows:
+        report.source_rows += 1
+        result = resolve_identity(db, row, approved_aliases=approved_aliases)
+        report.add(result, row)
+        season, week, version = row.value("season"), row.value("week"), row.value("projection_version")
+        supplied_values = {field: number(row.value(field)) for field in WEEKLY_NUMERIC_FIELDS}
+        if (
+            result.player_id is None or not season or not season.isdigit() or not week or not week.isdigit()
+            or not version or any(value is None for value in supplied_values.values())
+        ):
+            if result.player_id is not None:
+                report.conflicts += 1
+                report.manual_review.append({
+                    "row_number": row.row_number, "outcome": MatchOutcome.CONFLICT,
+                    "detail": "weekly projections require season, week, version, and every published numeric field",
+                })
+            continue
+        if len(version) > 20:
+            report.conflicts += 1
+            report.manual_review.append({"row_number": row.row_number, "outcome": MatchOutcome.CONFLICT, "detail": "projection_version exceeds 20 characters"})
+            continue
+        team = db.scalar(select(CollegeTeam).where(CollegeTeam.name == (row.value("school") or "")))
+        if team is None:
+            report.conflicts += 1
+            report.manual_review.append({"row_number": row.row_number, "outcome": MatchOutcome.CONFLICT, "detail": "canonical team is not registered"})
+            continue
+        opponent_name = row.value("opponent_team")
+        opponent = db.scalar(select(CollegeTeam).where(CollegeTeam.name == opponent_name)) if opponent_name else None
+        if opponent_name and opponent is None:
+            report.conflicts += 1
+            report.manual_review.append({"row_number": row.row_number, "outcome": MatchOutcome.CONFLICT, "detail": "opponent team is not registered"})
+            continue
+        existing = db.scalar(select(WeeklyProjection).where(
+            WeeklyProjection.player_id == result.player_id, WeeklyProjection.season == int(season),
+            WeeklyProjection.week == int(week), WeeklyProjection.projection_version == version,
+        ))
+        values = {
+            **supplied_values,
+            "is_published": boolean(row.value("is_published")),
+            "projection_status": row.value("projection_status") or "ACTIVE",
+            "model_version": row.value("model_version") or "approved-staged-v1",
+            "team_id": team.id,
+            "opponent_team_id": opponent.id if opponent else None,
+            "baseline_games_played": int(number(row.value("baseline_games_played")) or 0),
+            "baseline_source": row.value("baseline_source") or "approved_staged_export",
+            "fallback_reason": row.value("fallback_reason"),
+        }
+        if existing and all(getattr(existing, key) == value for key, value in values.items()):
+            report.unchanged += 1
+            continue
+        if apply:
+            target = existing or WeeklyProjection(
+                player_id=result.player_id, season=int(season), week=int(week), projection_version=version
+            )
+            for key, value in values.items():
+                setattr(target, key, value)
+            if existing is None:
+                db.add(target)
+        report.updated += int(existing is not None)
+        report.inserted += int(existing is None)
+    return report
+
+
+def source_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_logical_backup(manifest_path: Path) -> dict[str, Any]:
+    """Require a readable, checksum-verified logical backup before any apply run."""
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    backup_path = Path(manifest["path"]).expanduser()
+    expected_hash = manifest["sha256"]
+    if not backup_path.is_file() or source_sha256(backup_path) != expected_hash:
+        raise ValueError("logical backup is missing or its SHA-256 checksum does not match the manifest")
+    if backup_path.stat().st_size == 0:
+        raise ValueError("logical backup is empty")
+    return {"path": str(backup_path), "sha256": expected_hash, "size": backup_path.stat().st_size}

--- a/docs/operations/production-player-enrichment.md
+++ b/docs/operations/production-player-enrichment.md
@@ -1,0 +1,75 @@
+# Controlled production player enrichment
+
+This runbook restores player-card enrichment without provider calls from the
+production API.  It is intentionally separate from canonical player, value,
+and preseason-projection reconciliation.
+
+## Current approved sources
+
+| Category | Approved source | Authority | Status |
+| --- | --- | --- | --- |
+| Canonical player identity | `reports/source-imports/2026/player-identities.csv` | reviewed 2026 identity workbook, manifest `player-identities.manifest.json` | available; 814 rows |
+| Preseason season projection | `reports/source-imports/2026/player-projections.csv` | reviewed 2026 projection workbook, manifest `player-projections.manifest.json` | available; 814 rows; not a weekly feed |
+| ESPN IDs and biographies | none | an ESPN client exists, but it is disabled and is not an approved staged export | **BLOCKED** |
+| Historical season totals | none | an ESPN historical parser and an approved-sheet importer exist, but no approved immutable 2026 import export is present | **BLOCKED** |
+| 2026 schedules | no staged export | `scripts/import_2026_team_schedules.py` names the canonical schedule workbook, but a reviewed immutable snapshot is not checked in | **BLOCKED** |
+| Weekly projections | none | approved season projections cannot be divided into weeks | **BLOCKED** |
+| Completed weekly stats | none | provider integrations are disabled for beta; no approved staged box-score export exists | **BLOCKED** |
+
+The fixture files under `vendor/espn-college-football-stats/tests/fixtures/`
+are test fixtures only and must never be used as a production source.
+
+## Staged source contract
+
+All source files are operator-supplied local CSV files, outside Git. Each row
+must include `provider`, `provider_player_id`, `provider_team_id`,
+`provider_team_name`, `player_name`, `school`, and `position`. A reviewed
+`verified-aliases.csv` may map exactly one `(provider, provider_player_id)` to
+one canonical `player_id`; it is not a name-based escape hatch.
+
+The matching outcome is always one of `EXACT`, `VERIFIED_ALIAS`, `AMBIGUOUS`,
+`NOT_FOUND`, or `CONFLICT`. Only the first two are eligible to write. A staged
+source row is never matched by name alone: school and canonical position are
+required, and a pre-existing provider ID must agree with both.
+
+Stage inputs are deliberately independent:
+
+1. `identities` adds a verified `player_provider_ids` mapping plus supplied
+   biography values. Headshots require `headshot_approved=true`; they remain
+   hidden while `PLAYER_HEADSHOTS_ENABLED=false`.
+2. `historical` imports supplied season totals and source metadata without
+   manufacturing missing numeric fields or fantasy points.
+3. `scripts/import_2026_team_schedules.py --source <approved-local-csv>`
+   remains the separate, canonical team-schedule stage. It accepts local
+   snapshots only. Player game logs derive from those team schedules, not
+   copied player schedules.
+4. `weekly-projections` remains blocked until a reviewed week-specific export
+   is supplied. It requires every published numeric output in the source;
+   absent values are rejected rather than synthesized. Do not use
+   `scripts/build_weekly_projections.py` as a substitute for an approved
+   weekly source.
+5. `completed-stats` accepts only a verified completed-game JSON stats payload
+   per player/week; it cannot create a schedule or a projection.
+
+## Operator flow
+
+1. Create a logical PostgreSQL backup outside Git, store its SHA-256 and file
+   path in a private JSON manifest, and verify it is readable.
+2. Run every staged command without `--apply`, save reports outside Git, and
+   stop for any `AMBIGUOUS`, `NOT_FOUND`, or `CONFLICT` row.
+3. Review the aggregate report and alias file. Do not add a fuzzy alias.
+4. Run exactly one approved stage with `--apply --logical-backup-manifest`.
+   The stage commits once or rolls back completely.
+5. Run the same dry run again; already applied source rows must report
+   `unchanged`.
+
+Example (dry run only):
+
+```sh
+PYTHONPATH=. uv run python scripts/import_player_enrichment.py \
+  --stage identities --input /secure/staging/espn-identities.csv \
+  --verified-aliases /secure/staging/verified-aliases.csv
+```
+
+The command reports aggregate identity outcomes and source row numbers only. It
+never fetches a provider, logs credentials, or prints raw provider payloads.

--- a/scripts/import_2026_team_schedules.py
+++ b/scripts/import_2026_team_schedules.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from urllib.request import Request, urlopen
 
 from collegefootballfantasy_api.app.db.session import SessionLocal
 from collegefootballfantasy_api.app.models.registry import load_all_models
@@ -20,12 +19,14 @@ from collegefootballfantasy_api.app.services.team_schedule_import import (
 )
 
 
-DEFAULT_SOURCE = "https://docs.google.com/spreadsheets/d/1JnoISIE2fr_l7ze5qtAe2DIN4nFlI3CaZMdvaNHEnZQ/export?format=csv&gid=1843438972"
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Import canonical 2026 team schedules for player Game Logs.")
-    parser.add_argument("--source", default=DEFAULT_SOURCE, help="Google Sheet CSV export URL or a local CSV file path.")
+    parser.add_argument(
+        "--source",
+        type=Path,
+        required=True,
+        help="Approved local CSV snapshot. Live URLs are intentionally unsupported.",
+    )
     parser.add_argument("--season", type=int, default=2026)
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--dry-run", action="store_true", help="Validate and report only (default).")
@@ -34,13 +35,11 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_source(source: str) -> str:
-    source_path = Path(source).expanduser()
-    if source_path.exists():
-        return source_path.read_text(encoding="utf-8")
-    request = Request(source, headers={"User-Agent": "CollegeFootballFantasyScheduleImporter/1.0"})
-    with urlopen(request, timeout=30) as response:
-        return response.read().decode("utf-8-sig")
+def load_source(source: Path) -> str:
+    source_path = source.expanduser().resolve()
+    if not source_path.is_file():
+        raise ValueError("Schedule source must be an approved local CSV snapshot.")
+    return source_path.read_text(encoding="utf-8-sig")
 
 
 def main() -> int:

--- a/scripts/import_player_enrichment.py
+++ b/scripts/import_player_enrichment.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Run one approved, staged player-enrichment import.
+
+This command does not fetch a provider.  It accepts only a local CSV and is a
+dry run by default.  ``--apply`` requires a readable, checksum-verified
+logical-backup manifest and wraps the selected stage in one transaction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from collegefootballfantasy_api.app.db.model_registry import ensure_models_registered
+from collegefootballfantasy_api.app.db.session import SessionLocal
+from collegefootballfantasy_api.app.services.player_enrichment_import import (
+    IDENTITY_FIELDS,
+    WEEKLY_NUMERIC_FIELDS,
+    import_completed_weekly_stats,
+    import_historical_totals,
+    import_identities_and_bios,
+    import_weekly_projections,
+    read_csv_rows,
+    read_verified_aliases,
+    source_sha256,
+    verify_logical_backup,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=("identities", "historical", "weekly-projections", "completed-stats"), required=True)
+    parser.add_argument("--input", type=Path, required=True, help="Approved local CSV export; never a provider URL.")
+    parser.add_argument("--verified-aliases", type=Path, help="Reviewed alias CSV, required for non-exact mappings.")
+    parser.add_argument("--apply", action="store_true", help="Write one stage transactionally after a reviewed dry run.")
+    parser.add_argument("--logical-backup-manifest", type=Path, help="JSON manifest for a readable pre-import logical backup.")
+    parser.add_argument("--report", type=Path, help="Optional JSON report path outside source exports.")
+    return parser.parse_args()
+
+
+def required_columns(stage: str) -> set[str]:
+    if stage == "identities":
+        return IDENTITY_FIELDS
+    if stage == "historical":
+        return IDENTITY_FIELDS | {"season", "historical_team", "season_type"}
+    if stage == "weekly-projections":
+        return IDENTITY_FIELDS | {"season", "week", "projection_version", "opponent_team"} | WEEKLY_NUMERIC_FIELDS
+    return IDENTITY_FIELDS | {"season", "week", "stats_json"}
+
+
+def main() -> int:
+    args = parse_args()
+    source = args.input.expanduser().resolve()
+    if not source.is_file():
+        raise SystemExit("Approved staged source file does not exist.")
+    if args.apply and not args.logical_backup_manifest:
+        raise SystemExit("--apply requires --logical-backup-manifest from a verified logical PostgreSQL backup.")
+    backup = verify_logical_backup(args.logical_backup_manifest) if args.apply else None
+    rows = read_csv_rows(source, required=required_columns(args.stage))
+    aliases = read_verified_aliases(args.verified_aliases)
+    ensure_models_registered()
+    with SessionLocal() as db:
+        try:
+            if args.stage == "identities":
+                report = import_identities_and_bios(db, rows, approved_aliases=aliases, apply=args.apply)
+            elif args.stage == "historical":
+                report = import_historical_totals(db, rows, approved_aliases=aliases, apply=args.apply, source_sha256=source_sha256(source))
+            elif args.stage == "weekly-projections":
+                report = import_weekly_projections(db, rows, approved_aliases=aliases, apply=args.apply)
+            else:
+                report = import_completed_weekly_stats(db, rows, approved_aliases=aliases, apply=args.apply)
+            if report.has_unresolved_identity_conflicts:
+                db.rollback()
+                payload = {**report.as_dict(), "applied": False, "blocked": "unresolved identity review rows", "backup": backup}
+                print(json.dumps(payload, indent=2, sort_keys=True))
+                return 2
+            if args.apply:
+                db.commit()
+            else:
+                db.rollback()
+            payload = {**report.as_dict(), "applied": args.apply, "source_sha256": source_sha256(source), "backup": backup}
+        except Exception:
+            db.rollback()
+            raise
+    output = json.dumps(payload, indent=2, sort_keys=True)
+    print(output)
+    if args.report:
+        args.report.expanduser().resolve().write_text(output + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api/test_player_enrichment_import.py
+++ b/tests/api/test_player_enrichment_import.py
@@ -1,0 +1,148 @@
+from datetime import date
+
+from collegefootballfantasy_api.app.models.historical_stats import PlayerHistoricalSeasonStat
+from collegefootballfantasy_api.app.models.player import Player
+from collegefootballfantasy_api.app.models.provider_identity import PlayerProviderId
+from collegefootballfantasy_api.app.models.team_schedule import TeamSchedule
+from collegefootballfantasy_api.app.services.player_enrichment_import import (
+    EnrichmentSourceRow,
+    MatchOutcome,
+    import_historical_totals,
+    import_identities_and_bios,
+    import_weekly_projections,
+    resolve_identity,
+)
+from collegefootballfantasy_api.app.services.player_game_log import build_player_game_log
+
+
+def source_row(**overrides) -> EnrichmentSourceRow:
+    values = {
+        "provider": "espn",
+        "provider_player_id": "5084047",
+        "provider_team_id": "251",
+        "provider_team_name": "Texas Longhorns",
+        "player_name": "Arch Manning",
+        "school": "Texas",
+        "position": "QB",
+        "height": "6' 4\"",
+        "weight": "225 lbs",
+        "birthplace": "New Orleans, LA, USA",
+        "jersey": "16",
+        "player_class": "JR",
+        "profile_status": "Active",
+        "headshot_approved": "false",
+        "source_url": "https://approved.example/player/5084047",
+    }
+    values.update(overrides)
+    return EnrichmentSourceRow(row_number=2, values=values)
+
+
+def test_identity_stage_requires_full_exact_identity_and_is_idempotent(db_session):
+    player = Player(name="Arch Manning", school="Texas", position="QB", sheet_projected_season_points=409.0, current_value_rating=91)
+    db_session.add(player)
+    db_session.commit()
+
+    first = import_identities_and_bios(db_session, [source_row()], approved_aliases={}, apply=True)
+    db_session.commit()
+
+    assert first.exact == 1
+    assert first.inserted == 1
+    mapping = db_session.query(PlayerProviderId).one()
+    assert mapping.player_id == player.id
+    assert mapping.verification_status == "verified"
+    refreshed = db_session.get(Player, player.id)
+    assert refreshed.espn_height == "6' 4\""
+    assert refreshed.sheet_projected_season_points == 409.0
+    assert refreshed.current_value_rating == 91
+
+    second = import_identities_and_bios(db_session, [source_row()], approved_aliases={}, apply=True)
+    assert second.unchanged == 1
+    assert db_session.query(PlayerProviderId).count() == 1
+
+
+def test_identity_rejects_ambiguous_name_without_a_reviewed_alias(db_session):
+    db_session.add_all([
+        Player(name="Chris Johnson", school="Texas", position="RB"),
+        Player(name="Chris Johnson", school="Texas", position="RB"),
+    ])
+    db_session.commit()
+
+    result = resolve_identity(db_session, source_row(player_name="Chris Johnson", position="RB", provider_player_id="111"))
+
+    assert result.outcome is MatchOutcome.AMBIGUOUS
+
+
+def test_identity_marks_school_and_position_mismatches_for_review(db_session):
+    db_session.add(Player(name="Arch Manning", school="Texas", position="QB"))
+    db_session.commit()
+
+    school = resolve_identity(db_session, source_row(school="Georgia", provider_player_id="112"))
+    position = resolve_identity(db_session, source_row(position="WR", provider_player_id="113"))
+
+    assert school.outcome is MatchOutcome.CONFLICT
+    assert position.outcome is MatchOutcome.CONFLICT
+
+
+def test_reviewed_alias_can_only_resolve_the_explicit_provider_id(db_session):
+    player = Player(name="Arch Manning", school="Texas", position="QB")
+    db_session.add(player)
+    db_session.commit()
+
+    result = resolve_identity(
+        db_session,
+        source_row(player_name="Archibald Manning", provider_player_id="114"),
+        approved_aliases={("espn", "114"): player.id},
+    )
+
+    assert result.outcome is MatchOutcome.VERIFIED_ALIAS
+    assert result.player_id == player.id
+
+
+def test_historical_import_preserves_missing_fields_as_null(db_session):
+    player = Player(name="Arch Manning", school="Texas", position="QB")
+    db_session.add(player)
+    db_session.commit()
+    row = source_row(season="2025", historical_team="Texas", passing_yards="3828")
+
+    report = import_historical_totals(db_session, [row], approved_aliases={}, apply=True, source_sha256="a" * 64)
+    db_session.commit()
+
+    assert report.inserted == 1
+    stored = db_session.query(PlayerHistoricalSeasonStat).one()
+    assert stored.passing_yards == 3828.0
+    assert stored.receptions is None
+    assert stored.fantasy_points is None
+
+
+def test_game_logs_derive_from_team_schedule_without_copying_player_schedules(db_session):
+    player = Player(name="Arch Manning", school="Texas", position="QB")
+    db_session.add_all([
+        player,
+        TeamSchedule(
+            team_name="Texas", season=2026, week=1, opponent_name="Ohio State", location="home",
+            is_bye=False, game_date=date(2026, 9, 5), neutral_site=False, conference_game=False, date_confirmed=True,
+        ),
+    ])
+    db_session.commit()
+
+    game_log = build_player_game_log(db_session, player, season=2026)
+
+    assert len(game_log.games) == 1
+    assert game_log.games[0].opponent_name == "Ohio State"
+    assert game_log.games[0].stats is None
+
+
+def test_weekly_stage_rejects_incomplete_exports_instead_of_deriving_values(db_session):
+    player = Player(name="Arch Manning", school="Texas", position="QB")
+    db_session.add(player)
+    db_session.commit()
+
+    report = import_weekly_projections(
+        db_session,
+        [source_row(season="2026", week="1", projection_version="FINAL", opponent_team="Ohio State")],
+        approved_aliases={},
+        apply=False,
+    )
+
+    assert report.conflicts == 1
+    assert report.inserted == 0

--- a/tests/api/test_player_enrichment_import.py
+++ b/tests/api/test_player_enrichment_import.py
@@ -7,6 +7,7 @@ from collegefootballfantasy_api.app.models.team_schedule import TeamSchedule
 from collegefootballfantasy_api.app.services.player_enrichment_import import (
     EnrichmentSourceRow,
     MatchOutcome,
+    import_completed_weekly_stats,
     import_historical_totals,
     import_identities_and_bios,
     import_weekly_projections,
@@ -112,6 +113,23 @@ def test_historical_import_preserves_missing_fields_as_null(db_session):
     assert stored.passing_yards == 3828.0
     assert stored.receptions is None
     assert stored.fantasy_points is None
+
+    rerun = import_historical_totals(db_session, [row], approved_aliases={}, apply=True, source_sha256="a" * 64)
+    assert rerun.unchanged == 1
+
+
+def test_completed_stats_stage_is_idempotent_and_keeps_only_supplied_stats(db_session):
+    player = Player(name="Arch Manning", school="Texas", position="QB")
+    db_session.add(player)
+    db_session.commit()
+    row = source_row(season="2026", week="1", stats_json='{"passing_yards": 250, "passing_touchdowns": 2}')
+
+    first = import_completed_weekly_stats(db_session, [row], approved_aliases={}, apply=True)
+    db_session.commit()
+    rerun = import_completed_weekly_stats(db_session, [row], approved_aliases={}, apply=True)
+
+    assert first.inserted == 1
+    assert rerun.unchanged == 1
 
 
 def test_game_logs_derive_from_team_schedule_without_copying_player_schedules(db_session):

--- a/tests/scripts/test_import_2026_team_schedules.py
+++ b/tests/scripts/test_import_2026_team_schedules.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "import_2026_team_schedules.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("import_2026_team_schedules", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_schedule_stage_refuses_live_urls(tmp_path):
+    module = load_module()
+
+    with pytest.raises(ValueError, match="approved local CSV snapshot"):
+        module.load_source(Path("https://docs.google.com/schedule.csv"))
+
+    source = tmp_path / "schedule.csv"
+    source.write_text("Season,Team\n2026,Texas\n", encoding="utf-8")
+    assert module.load_source(source) == "Season,Team\n2026,Texas\n"


### PR DESCRIPTION
## Controlled player enrichment pipeline

This PR adds a source-gated, staged importer. It does not modify production data, call a provider, merge, or deploy.

- Requires a local reviewed CSV; no live URLs are accepted for the schedule stage.
- Deterministic outcomes are `EXACT`, `VERIFIED_ALIAS`, `AMBIGUOUS`, `NOT_FOUND`, and `CONFLICT`.
- Only exact matches and explicitly reviewed provider-ID aliases can write.
- `--apply` requires a readable SHA-256-verified logical backup manifest and commits a single stage transactionally.
- Missing fields stay null; season projections are never divided into weekly projections.

Current source inventory: canonical identity and season-projection snapshots are approved. Immutable provider identity/bio, historical season, schedule, weekly-projection, and completed-stat source exports remain blocked pending owner approval.

Validation: 22 focused backend tests, frontend TypeScript checks, and production build passed.
