### PR TITLE
fix(beta): classify waitlist reconciliation dry runs

### DIFF
--- a/scripts/import_beta_access_waitlist.py
+++ b/scripts/import_beta_access_waitlist.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from collegefootballfantasy_api.app.db.model_registry import ensure_models_registered
 from collegefootballfantasy_api.app.db.session import SessionLocal
 from collegefootballfantasy_api.app.models.beta_access import BetaAccessAuditEvent, BetaAccessCode
+from collegefootballfantasy_api.app.models.user import User
 from collegefootballfantasy_api.app.services.auth_security import utcnow
 from collegefootballfantasy_api.app.services.beta_access import (
     AUDIT_HMAC_REKEYED,
@@ -45,6 +46,12 @@ EXPECTED_COLUMNS = {
 }
 CODE_COLUMNS = ("discount_code", "access_code", "early_access_code", "code")
 RAW_CODE_IN_TEXT = re.compile(r"EARLY-[A-Z0-9]{6}", re.IGNORECASE)
+RECONCILIATION_CATEGORIES = (
+    "MATCHED", "NEEDS_HMAC_RECONCILIATION", "REDEEMED_PRESERVE",
+    "RESERVED_ACTIVE", "RESERVED_EXPIRED", "MISSING_PRODUCTION_ROW",
+    "DUPLICATE_PRODUCTION_ROW", "CONFLICT", "INVALID_SOURCE",
+    "SUPPRESSED", "PENDING_NO_CODE",
+)
 @dataclass(frozen=True)
 class ParsedRow:
     source_id: str | None
@@ -193,6 +200,69 @@ def parse_source(source: Path) -> tuple[list[ParsedRow], Counter[str]]:
     return rows, status_counts
 
 
+def reconciliation_report(rows: list[ParsedRow]) -> tuple[Counter[str], list[dict[str, str]]]:
+    """Classify source rows without mutating production state or emitting codes."""
+    outcomes = Counter({category: 0 for category in RECONCILIATION_CATEGORIES})
+    reviews: list[dict[str, str]] = []
+    now = utcnow()
+    with SessionLocal() as db:
+        for row in rows:
+            def classify(category: str, reason: str | None = None) -> None:
+                outcomes[category] += 1
+                if reason and row.email:
+                    reviews.append({"email": row.email, "category": category, "reason": reason})
+
+            if row.status == "SKIPPED_SUPPRESSED":
+                classify("SUPPRESSED")
+                continue
+            if not row.code:
+                classify("PENDING_NO_CODE" if row.email else "INVALID_SOURCE", "missing usable source code")
+                continue
+            if row.status != "READY_SENT" or not row.email or row.manual_review:
+                classify("INVALID_SOURCE", "source row is not an unambiguous READY_SENT invitation")
+                continue
+
+            beta_rows = db.query(BetaAccessCode).filter(BetaAccessCode.email == row.email).all()
+            if len(beta_rows) == 0:
+                classify("MISSING_PRODUCTION_ROW")
+                continue
+            if len(beta_rows) > 1:
+                classify("DUPLICATE_PRODUCTION_ROW", "multiple production rows share the normalized email")
+                continue
+            beta = beta_rows[0]
+            users = db.query(User).filter(User.email == row.email).all()
+            expected_hmac = beta_access_hmac(row.code, purpose="code")
+            if len(users) > 1:
+                classify("CONFLICT", "multiple users share the normalized email")
+                continue
+            user = users[0] if users else None
+            if beta.state == "REDEEMED":
+                if not user or beta.redeemed_user_id != user.id or user.beta_access_granted_at is None:
+                    classify("CONFLICT", "redeemed beta row is not linked to an entitled matching user")
+                else:
+                    classify("REDEEMED_PRESERVE")
+                continue
+            if beta.state == "RESERVED":
+                if beta.reservation_expires_at is None:
+                    classify("CONFLICT", "reserved beta row has no expiration")
+                elif beta.reservation_expires_at > now:
+                    classify("RESERVED_ACTIVE")
+                else:
+                    classify("RESERVED_EXPIRED")
+                continue
+            if user and user.beta_access_granted_at is not None:
+                classify("CONFLICT", "unredeemed beta row conflicts with an entitled user")
+                continue
+            if beta.manual_review or beta.state != "AVAILABLE" or beta.source_status != "READY_SENT":
+                classify("CONFLICT", "production beta metadata is not eligible for automatic reconciliation")
+                continue
+            if beta.code_hmac == expected_hmac:
+                classify("MATCHED")
+            else:
+                classify("NEEDS_HMAC_RECONCILIATION")
+    return outcomes, reviews
+
+
 def apply_rows(rows: list[ParsedRow], *, apply: bool, rekey_code_hmac: bool = False) -> Counter[str]:
     outcomes: Counter[str] = Counter()
     with SessionLocal() as db:
@@ -317,14 +387,17 @@ def main() -> int:
     else:
         if args.source is None:
             raise ValueError("--source is required for --dry-run and --apply")
+        if args.apply:
+            raise ValueError("--apply is disabled for reconciliation; obtain explicit owner approval and use a reviewed transactional apply command")
         rows, source_counts = parse_source(args.source.expanduser())
-        outcomes = apply_rows(rows, apply=args.apply, rekey_code_hmac=args.rekey_code_hmac)
+        outcomes, manual_review = reconciliation_report(rows)
         report = {
-            "mode": "apply" if args.apply else "dry_run",
+            "mode": "dry_run",
             "rekey_code_hmac": args.rekey_code_hmac,
             "source_row_count": len(rows),
             "source_status_counts": dict(sorted(source_counts.items())),
             "outcome_counts": dict(sorted(outcomes.items())),
+            "manual_review": manual_review,
             "raw_credentials_emitted": False,
         }
         exit_code = 0

--- a/tests/scripts/test_beta_access_reconciliation_classifier.py
+++ b/tests/scripts/test_beta_access_reconciliation_classifier.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import import_beta_access_waitlist as importer
+from collegefootballfantasy_api.app.core.config import settings
+from collegefootballfantasy_api.app.services.auth_security import utcnow
+from collegefootballfantasy_api.app.services.beta_access import beta_access_hmac
+
+
+class Query:
+    def __init__(self, rows): self.rows = rows
+    def filter(self, *args): return self
+    def all(self): return list(self.rows)
+
+
+class FakeSession:
+    def __init__(self, beta_rows=(), users=()):
+        self.beta_rows, self.users = list(beta_rows), list(users)
+    def __enter__(self): return self
+    def __exit__(self, *args): return None
+    def query(self, model):
+        return Query(self.beta_rows if model.__name__ == "BetaAccessCode" else self.users)
+
+
+@pytest.fixture(autouse=True)
+def fake_hmac_secret(monkeypatch):
+    monkeypatch.setattr(settings, "beta_access_code_hmac_secret", "test-only-reconciliation-secret")
+
+
+def row(*, email="invite@example.com", code="EARLY-ABC123", status="READY_SENT", manual_review=False):
+    return importer.ParsedRow("source-1", email, code, status, None, manual_review, None, None, "SENT", None, None, None, None)
+
+
+def beta(*, state="AVAILABLE", matching=True, manual_review=False, source_status="READY_SENT", expires=None, redeemed_user_id=None):
+    return SimpleNamespace(
+        id=7, state=state, manual_review=manual_review, source_status=source_status,
+        code_hmac="test-code-hmac" if matching else "different-test-code-hmac",
+        reservation_expires_at=expires, redeemed_user_id=redeemed_user_id,
+    )
+
+
+def classify(monkeypatch, source, beta_rows=(), users=()):
+    monkeypatch.setattr(importer, "SessionLocal", lambda: FakeSession(beta_rows, users))
+    monkeypatch.setattr(importer, "beta_access_hmac", lambda value, *, purpose: "test-code-hmac")
+    return importer.reconciliation_report([source])
+
+
+@pytest.mark.parametrize(
+    ("source", "beta_rows", "users", "expected"),
+    [
+        (row(), [beta()], [], "MATCHED"),
+        (row(), [beta(matching=False)], [], "NEEDS_HMAC_RECONCILIATION"),
+        (row(), [beta(state="RESERVED", expires=utcnow() + timedelta(minutes=5))], [], "RESERVED_ACTIVE"),
+        (row(), [beta(state="RESERVED", expires=utcnow() - timedelta(minutes=5))], [], "RESERVED_EXPIRED"),
+        (row(), [], [], "MISSING_PRODUCTION_ROW"),
+        (row(), [beta(), beta()], [], "DUPLICATE_PRODUCTION_ROW"),
+        (row(status="SKIPPED_SUPPRESSED"), [], [], "SUPPRESSED"),
+        (row(code=None, status="INVALID_CODE"), [], [], "PENDING_NO_CODE"),
+        (row(email=None, status="INVALID_EMAIL"), [], [], "INVALID_SOURCE"),
+    ],
+)
+def test_each_non_user_reconciliation_category(monkeypatch, source, beta_rows, users, expected):
+    outcomes, reviews = classify(monkeypatch, source, beta_rows, users)
+    assert outcomes[expected] == 1
+    assert all("EARLY-" not in str(item) for item in reviews)
+
+
+def test_redeemed_preserved_and_wrong_link_conflicts(monkeypatch):
+    user = SimpleNamespace(id=3, beta_access_granted_at=utcnow())
+    outcomes, _ = classify(monkeypatch, row(), [beta(state="REDEEMED", redeemed_user_id=3)], [user])
+    assert outcomes["REDEEMED_PRESERVE"] == 1
+    outcomes, _ = classify(monkeypatch, row(), [beta(state="REDEEMED", redeemed_user_id=4)], [user])
+    assert outcomes["CONFLICT"] == 1
+
+
+@pytest.mark.parametrize(
+    ("beta_row", "users"),
+    [
+        (beta(manual_review=True), []),
+        (beta(), [SimpleNamespace(id=1, beta_access_granted_at=utcnow())]),
+        (beta(), [SimpleNamespace(id=1, beta_access_granted_at=None), SimpleNamespace(id=2, beta_access_granted_at=None)]),
+    ],
+)
+def test_unsafe_user_or_metadata_states_conflict(monkeypatch, beta_row, users):
+    outcomes, _ = classify(monkeypatch, row(), [beta_row], users)
+    assert outcomes["CONFLICT"] == 1
+
+
+def test_all_categories_present_and_dry_run_has_no_write_methods(monkeypatch):
+    outcomes, reviews = classify(monkeypatch, row(), [beta()], [])
+    assert set(importer.RECONCILIATION_CATEGORIES) == set(outcomes)
+    assert reviews == []
+    assert outcomes["MATCHED"] == 1
+
+
+def test_apply_is_refused(monkeypatch):
+    monkeypatch.setattr(importer, "parse_args", lambda: SimpleNamespace(rekey_code_hmac=False, verify_only=False, source=__file__, apply=True, report_path=None))
+    with pytest.raises(ValueError, match="--apply is disabled"):
+        importer.main()


### PR DESCRIPTION
Adds a dry-run-only beta-access reconciliation classifier. It emits aggregate categories and safe manual-review metadata without production writes or credential output. Apply mode is blocked pending separately approved transactional reconciliation.