### PR TITLE
fix(deploy): recover API behind Alembic readiness gate

### DIFF
--- a/railway.api.toml
+++ b/railway.api.toml
@@ -3,10 +3,6 @@ builder = "RAILPACK"
 buildCommand = "uv sync --frozen"
 
 [deploy]
-# Railway must complete both commands before it starts or promotes the API.
-preDeployCommand = [
-  "PYTHONPATH=. uv run alembic -c api/alembic.ini upgrade head && PYTHONPATH=. uv run python scripts/check_alembic_head.py",
-]
 startCommand = "PYTHONPATH=. uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health/ready"
 healthcheckTimeout = 100

--- a/tests/scripts/test_production_api_routing_contract.py
+++ b/tests/scripts/test_production_api_routing_contract.py
@@ -48,18 +48,11 @@ def test_production_manifest_names_one_canonical_frontend_and_railway_api_contra
     assert web["required_vercel_system_environment_variables"] == ["VERCEL_GIT_COMMIT_SHA"]
 
 
-def test_railway_api_config_gates_migrations_before_the_port_aware_api_starts():
+def test_railway_api_recovery_config_uses_readiness_without_a_predeploy_hook():
     config = tomllib.loads((REPO_ROOT / "railway.api.toml").read_text(encoding="utf-8"))
 
     assert config["build"] == {"builder": "RAILPACK", "buildCommand": "uv sync --frozen"}
-    pre_deploy_commands = config["deploy"]["preDeployCommand"]
-    assert len(pre_deploy_commands) == 1
-    assert pre_deploy_commands[0] == (
-        "PYTHONPATH=. uv run alembic -c api/alembic.ini upgrade head && "
-        "PYTHONPATH=. uv run python scripts/check_alembic_head.py"
-    )
-    assert pre_deploy_commands[0].index("alembic -c api/alembic.ini upgrade head") < pre_deploy_commands[0].index("&&")
-    assert pre_deploy_commands[0].index("&&") < pre_deploy_commands[0].index("scripts/check_alembic_head.py")
+    assert "preDeployCommand" not in config["deploy"]
     assert config["deploy"]["startCommand"] == (
         "PYTHONPATH=. uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port $PORT"
     )


### PR DESCRIPTION
## Recovery scope

Temporarily removes Railway API `preDeployCommand` so the current API can start and Railway can gate promotion through `/health/ready`.

The readiness endpoint continues to require database connectivity, an `alembic_version` table, and exact equality between the database revision and repository head. No migrations, application data, or deployment behavior outside the Railway pre-deploy hook changes.

## Validation

- Focused deployment-contract and readiness tests: 13 passed
- Backend suite: 490 passed
- TypeScript: passed
- Frontend Vitest: 44 files / 198 tests passed
- Production build: passed

Required Docker clean-boot and real-stack validation will run through PR CI.

> This is a temporary production recovery configuration. Automatic migration execution must be reintroduced in a separate hardening PR after the API release is aligned.