### PR TITLE
fix(deploy): restore production Railway API startup

### DIFF
--- a/deployments.yaml
+++ b/deployments.yaml
@@ -89,12 +89,13 @@ environments:
       railway_service: College-Football-Fantasy-App API
       railway_root_directory: /
       railway_config_path: /railway.api.toml
+      railway_builder: DOCKERFILE
+      railway_dockerfile_path: Dockerfile.api
       host: 0.0.0.0
       port_env: PORT
-      build_command: uv sync --frozen
       migrate_command: PYTHONPATH=. uv run alembic -c api/alembic.ini upgrade head
       verify_migrations_command: PYTHONPATH=. uv run python scripts/check_alembic_head.py
-      start_command: PYTHONPATH=. uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port $PORT
+      start_command: sh -c 'exec uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port "$PORT"'
       health_path: /health
       readiness_path: /health/ready
       minimum_replicas: 1

--- a/railway.api.toml
+++ b/railway.api.toml
@@ -1,9 +1,9 @@
 [build]
-builder = "RAILPACK"
-buildCommand = "uv sync --frozen"
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile.api"
 
 [deploy]
-startCommand = "PYTHONPATH=. uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port $PORT"
+startCommand = "sh -c 'exec uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port \"$PORT\"'"
 healthcheckPath = "/health/ready"
 healthcheckTimeout = 100
 restartPolicyType = "ALWAYS"

--- a/tests/scripts/test_production_api_routing_contract.py
+++ b/tests/scripts/test_production_api_routing_contract.py
@@ -34,8 +34,12 @@ def test_production_manifest_names_one_canonical_frontend_and_railway_api_contra
 
     assert api["railway_config_path"] == "/railway.api.toml"
     assert api["railway_root_directory"] == "/"
+    assert api["railway_builder"] == "DOCKERFILE"
+    assert api["railway_dockerfile_path"] == "Dockerfile.api"
     assert api["port_env"] == "PORT"
-    assert api["start_command"].endswith("--port $PORT")
+    assert api["start_command"] == (
+        "sh -c 'exec uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port \"$PORT\"'"
+    )
     assert api["migrate_command"] == "PYTHONPATH=. uv run alembic -c api/alembic.ini upgrade head"
     assert api["verify_migrations_command"] == "PYTHONPATH=. uv run python scripts/check_alembic_head.py"
 
@@ -51,11 +55,17 @@ def test_production_manifest_names_one_canonical_frontend_and_railway_api_contra
 def test_railway_api_recovery_config_uses_readiness_without_a_predeploy_hook():
     config = tomllib.loads((REPO_ROOT / "railway.api.toml").read_text(encoding="utf-8"))
 
-    assert config["build"] == {"builder": "RAILPACK", "buildCommand": "uv sync --frozen"}
+    assert config["build"] == {"builder": "DOCKERFILE", "dockerfilePath": "Dockerfile.api"}
     assert "preDeployCommand" not in config["deploy"]
-    assert config["deploy"]["startCommand"] == (
-        "PYTHONPATH=. uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port $PORT"
+    start_command = config["deploy"]["startCommand"]
+    assert start_command == (
+        "sh -c 'exec uv run uvicorn collegefootballfantasy_api.app.main:app --host 0.0.0.0 --port \"$PORT\"'"
     )
+    assert not start_command.startswith("PYTHONPATH=.")
+    assert "sh -c" in start_command
+    assert "exec uv run uvicorn" in start_command
+    assert "--host 0.0.0.0" in start_command
+    assert '"$PORT"' in start_command
     assert config["deploy"]["healthcheckPath"] == "/health/ready"
     assert config["deploy"]["healthcheckTimeout"] == 100
     assert config["deploy"]["restartPolicyType"] == "ALWAYS"


### PR DESCRIPTION
## Emergency production API startup fix

Restores Railway API startup without merging unfinished beta UI work.

- Aligns the checked-in Railway contract with the proven Dockerfile build mode (`Dockerfile.api`).
- Replaces the invalid exec-form `PYTHONPATH=.` assignment with a shell-safe `sh -c 'exec … "$PORT"'` command.
- Preserves `/health/ready`, timeout, restart policy, and no-predeploy recovery policy.

Only `railway.api.toml`, `deployments.yaml`, and `tests/scripts/test_production_api_routing_contract.py` are changed. No migrations, data, UI, navigation, Pick 6, CSS, or Playwright changes are included.

Validation: 4 targeted deployment-routing tests passed; 6 combined deployment-contract tests passed.
