### PR TITLE
fix(data): seal beta content and player-data imports

### DIFF
--- a/api/app/services/cfb27_player_sync.py
+++ b/api/app/services/cfb27_player_sync.py
@@ -5,6 +5,7 @@ import csv
 import hashlib
 import re
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -90,12 +91,29 @@ def cfb27_identity_key(*, name: str | None, school: str | None, position: str | 
     )
 
 
+def _whole_number(value: object, *, field: str, row_number: int) -> int:
+    """Parse an integer while accepting XLSX-exported whole-number decimals.
+
+    A value such as ``94.0`` is the normal serialized representation of an
+    Excel numeric OVR cell.  Fractions remain invalid so a source cannot turn
+    a board rank or malformed value into a player rating by truncation.
+    """
+
+    try:
+        parsed = Decimal(str(value).strip())
+    except (InvalidOperation, ValueError) as error:
+        raise ValueError(f"CFB27 row {row_number} has invalid {field} {value!r}; expected a whole number.") from error
+    if not parsed.is_finite() or parsed != parsed.to_integral_value():
+        raise ValueError(f"CFB27 row {row_number} has invalid {field} {value!r}; expected a whole number.")
+    return int(parsed)
+
+
 def _parse_cfb27_rating_rows(source: object, *, source_label: str) -> tuple[Cfb27Rating, ...]:
     if not isinstance(source, list):
         raise ValueError(f"CFB27 source {source_label} must contain a JSON list of reviewed rating rows.")
     normalized_rows = []
     for index, row in enumerate(source, start=1):
-        overall = int(row["overall"])
+        overall = _whole_number(row["overall"], field="overall", row_number=index)
         if not CFB27_MIN_OVERALL <= overall <= CFB27_MAX_OVERALL:
             raise ValueError(
                 f"CFB27 row {index} has invalid overall {overall}; "
@@ -107,7 +125,7 @@ def _parse_cfb27_rating_rows(source: object, *, source_label: str) -> tuple[Cfb2
         normalized_rows.append(
             {
                 "source_order": index - 1,
-                "position_rank": int(row.get("rank") or 0),
+                "position_rank": _whole_number(row.get("rank") or 0, field="rank", row_number=index),
                 "name": str(row["name"]),
                 "school": str(row["school"]),
                 "position": position,

--- a/api/app/services/saturday_pick_service.py
+++ b/api/app/services/saturday_pick_service.py
@@ -7,6 +7,7 @@ browser cannot bypass the same-position or deadline rules.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
@@ -43,6 +44,14 @@ from collegefootballfantasy_api.app.domain.stat_normalization import normalize_p
 PUBLIC_POSITIONS = ("QB", "RB", "WR", "TE")
 DEFAULT_ROTATION = PUBLIC_POSITIONS
 FINAL_GAME_STATUSES = {"FINAL", "STAT_CORRECTED"}
+
+
+@dataclass(frozen=True)
+class ContestReadiness:
+    """Read-only facts required before creating a Saturday Pick 6 contest."""
+
+    featured: list[tuple[Player, TeamSchedule]]
+    lock_at: datetime
 
 
 def utc_now() -> datetime:
@@ -143,7 +152,13 @@ def _validate_featured_players(
     return validated
 
 
-def create_contest(db: Session, payload: SaturdayPickContestCreate, actor: User) -> SaturdayPickContest:
+def validate_contest_readiness(db: Session, payload: SaturdayPickContestCreate) -> ContestReadiness:
+    """Validate contest creation with SELECT-only queries.
+
+    Operational dry runs must not add ORM objects or call ``flush``. PostgreSQL
+    sequence values advance on a flush even if the transaction is rolled back.
+    """
+
     if db.query(SaturdayPickContest.id).filter(
         SaturdayPickContest.season == payload.season,
         SaturdayPickContest.week_number == payload.week_number,
@@ -153,9 +168,15 @@ def create_contest(db: Session, payload: SaturdayPickContestCreate, actor: User)
     earliest_kickoff = min(as_utc(schedule.kickoff_at) for _, schedule in featured)
     if payload.lock_at is not None and as_utc(payload.lock_at) != earliest_kickoff:
         raise ValueError("Saturday Pick 6 locks exactly at the first featured player's kickoff.")
-    lock_at = earliest_kickoff
     if payload.position_overridden and not payload.override_reason:
         raise ValueError("A manual position override requires an audit reason.")
+    return ContestReadiness(featured=featured, lock_at=earliest_kickoff)
+
+
+def create_contest(db: Session, payload: SaturdayPickContestCreate, actor: User) -> SaturdayPickContest:
+    readiness = validate_contest_readiness(db, payload)
+    featured = readiness.featured
+    lock_at = readiness.lock_at
     contest = SaturdayPickContest(
         season=payload.season,
         week_number=payload.week_number,

--- a/api/app/services/team_schedule_import.py
+++ b/api/app/services/team_schedule_import.py
@@ -12,7 +12,7 @@ import io
 import re
 from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass, field
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from zoneinfo import ZoneInfo
 
 from sqlalchemy import inspect
@@ -76,7 +76,7 @@ def _parse_kickoff(game_date: date | None, value: object | None) -> datetime | N
     for pattern in ("%Y-%m-%d %I:%M %p", "%Y-%m-%d %I %p"):
         try:
             parsed = datetime.strptime(f"{game_date.isoformat()} {time_text.upper()}", pattern)
-            return parsed.replace(tzinfo=EASTERN_TIME)
+            return parsed.replace(tzinfo=EASTERN_TIME).astimezone(UTC)
         except ValueError:
             continue
     raise ValueError(f"unsupported Eastern kickoff time {time_text!r}")

--- a/api/app/services/team_schedule_import.py
+++ b/api/app/services/team_schedule_import.py
@@ -12,6 +12,7 @@ import io
 import re
 from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass, field
+from decimal import Decimal, InvalidOperation
 from datetime import UTC, date, datetime
 from zoneinfo import ZoneInfo
 
@@ -55,6 +56,27 @@ def _slug(value: str) -> str:
 
 def _bool(value: object | None) -> bool:
     return (_text(value) or "").lower() in {"yes", "true", "1", "y"}
+
+
+def _whole_number(value: object | None, *, field: str) -> int:
+    """Accept a CSV integer or an XLSX-exported whole-number decimal.
+
+    Excel commonly serializes a numeric cell as ``1.0`` when an XLSX source is
+    flattened to CSV.  That is the same schedule week as ``1``.  Fractions,
+    non-finite values, and arbitrary text remain invalid rather than being
+    silently truncated.
+    """
+
+    raw = _text(value)
+    if raw is None:
+        raise ValueError(f"{field} is required")
+    try:
+        parsed = Decimal(raw)
+    except InvalidOperation as error:
+        raise ValueError(f"{field} must be a whole number, got {raw!r}") from error
+    if not parsed.is_finite() or parsed != parsed.to_integral_value():
+        raise ValueError(f"{field} must be a whole number, got {raw!r}")
+    return int(parsed)
 
 
 def _parse_date(value: object | None) -> date | None:
@@ -167,7 +189,7 @@ def parse_schedule_csv(csv_text: str, *, season: int) -> tuple[list[ScheduleSour
             week_text = _text(raw.get("Week"))
             if not team_name or not conference or not week_text:
                 raise ValueError("team, conference, and week are required")
-            week = int(week_text)
+            week = _whole_number(week_text, field="week")
             if week < 0 or week > 30:
                 raise ValueError(f"week {week} is outside the supported range")
             if location not in VALID_LOCATIONS:

--- a/scripts/audit_annual_projection_scoring.py
+++ b/scripts/audit_annual_projection_scoring.py
@@ -21,7 +21,7 @@ from collegefootballfantasy_api.app.domain.scoring_engine import calculate_playe
 SOURCE_COLUMNS = {
     "pass_yards": "PASS YDS",
     "pass_tds": "PASS TDS",
-    "passing_interceptions": "INTS",
+    "interceptions": "INTS",
     "rush_yards": "RUSH YDS",
     "rush_tds": "RUSH TDS",
     "receptions": "RECEPTIONS",
@@ -52,6 +52,27 @@ def _position(row: dict[str, str]) -> str:
 
 def _canonical_stats(row: dict[str, str]) -> dict[str, str | None]:
     return {stat: row.get(column) for stat, column in SOURCE_COLUMNS.items()}
+
+
+def canonical_projection_points(row: dict[str, str]) -> float | None:
+    """Return a component-derived annual total when the source can prove one.
+
+    ``FANTASY PROJ.`` is retained as a source-provided comparison value only.
+    It is not an input to the app's standard-scoring total.  In particular, a
+    kicker total-FG value cannot be translated into the app's distance-tiered
+    kicker scoring without inventing a distance distribution.
+    """
+
+    position = _position(row)
+    if not position:
+        return None
+    required_columns = tuple(SOURCE_COLUMNS.values())
+    if any(_component_state(row.get(column)) != "valid" for column in required_columns):
+        return None
+    if position == "K" and _number(row.get("FG")) not in (None, 0.0):
+        return None
+    points, _ = calculate_player_fantasy_points(_canonical_stats(row), {}, position)
+    return points
 
 
 def audit(rows: list[dict[str, str]]) -> dict[str, Any]:
@@ -94,11 +115,11 @@ def audit(rows: list[dict[str, str]]) -> dict[str, Any]:
             reason = "annual_sheet_has_total_field_goals_without_distance_buckets"
         elif sheet_points is None:
             outcome = "MISSING_SHEET_TOTAL"
-            canonical_points, _ = calculate_player_fantasy_points(_canonical_stats(row), {}, position)
+            canonical_points = canonical_projection_points(row)
             difference = None
             reason = "FANTASY_PROJ_blank"
         else:
-            canonical_points, _ = calculate_player_fantasy_points(_canonical_stats(row), {}, position)
+            canonical_points = canonical_projection_points(row)
             difference = round(canonical_points - sheet_points, 2)
             if abs(difference) < 0.005:
                 outcome = "EXACT_MATCH"

--- a/scripts/audit_annual_projection_scoring.py
+++ b/scripts/audit_annual_projection_scoring.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Reconcile annual Sheet totals with the app's canonical scoring contract.
+
+This is a release gate only.  It never writes a database row and never treats
+the workbook's ``FANTASY PROJ.`` column as a weekly projection input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from collegefootballfantasy_api.app.domain.scoring_engine import calculate_player_fantasy_points
+
+
+SOURCE_COLUMNS = {
+    "pass_yards": "PASS YDS",
+    "pass_tds": "PASS TDS",
+    "passing_interceptions": "INTS",
+    "rush_yards": "RUSH YDS",
+    "rush_tds": "RUSH TDS",
+    "receptions": "RECEPTIONS",
+    "rec_yards": "REC YDS",
+    "rec_tds": "REC TDS",
+    "xp_made": "XP",
+}
+
+
+def _number(value: str | None) -> float | None:
+    try:
+        return float((value or "").replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _component_state(value: str | None) -> str:
+    """Return missing/invalid/valid without ever turning blanks into zero."""
+    text = (value or "").strip()
+    if not text:
+        return "missing"
+    return "valid" if _number(text) is not None else "invalid"
+
+
+def _position(row: dict[str, str]) -> str:
+    return (row.get("POSITION") or "").strip().upper()[:2]
+
+
+def _canonical_stats(row: dict[str, str]) -> dict[str, str | None]:
+    return {stat: row.get(column) for stat, column in SOURCE_COLUMNS.items()}
+
+
+def audit(rows: list[dict[str, str]]) -> dict[str, Any]:
+    outcomes: Counter[str] = Counter()
+    outcome_by_position: Counter[str] = Counter()
+    findings: list[dict[str, Any]] = []
+    max_difference = 0.0
+    for row_number, row in enumerate(rows, start=2):
+        position = _position(row)
+        identity = {
+            "player": (row.get("PLAYER") or "").strip() or None,
+            "team": (row.get("TEAM") or "").strip() or None,
+            "position": position or None,
+        }
+        sheet_points = _number(row.get("FANTASY PROJ."))
+        required_columns = tuple(SOURCE_COLUMNS.values())
+        missing_components = [column for column in required_columns if _component_state(row.get(column)) == "missing"]
+        invalid_components = [column for column in required_columns if _component_state(row.get(column)) == "invalid"]
+        if not identity["player"] or not identity["team"] or not identity["position"]:
+            outcome = "UNMATCHED_PLAYER"
+            canonical_points = None
+            difference = None
+            reason = "canonical_identity_fields_are_incomplete"
+        elif invalid_components:
+            outcome = "INVALID_COMPONENT"
+            canonical_points = None
+            difference = None
+            reason = "one_or_more_canonical_component_columns_are_invalid"
+        elif missing_components:
+            outcome = "MISSING_COMPONENT"
+            canonical_points = None
+            difference = None
+            reason = "one_or_more_canonical_component_columns_are_blank"
+        elif position == "K" and _number(row.get("FG")) not in (None, 0.0):
+            # The canonical kicker model requires distance buckets.  A total
+            # FG count cannot safely be allocated across them.
+            outcome = "UNSCORABLE_KICKER_DISTANCE"
+            canonical_points = None
+            difference = None
+            reason = "annual_sheet_has_total_field_goals_without_distance_buckets"
+        elif sheet_points is None:
+            outcome = "MISSING_SHEET_TOTAL"
+            canonical_points, _ = calculate_player_fantasy_points(_canonical_stats(row), {}, position)
+            difference = None
+            reason = "FANTASY_PROJ_blank"
+        else:
+            canonical_points, _ = calculate_player_fantasy_points(_canonical_stats(row), {}, position)
+            difference = round(canonical_points - sheet_points, 2)
+            if abs(difference) < 0.005:
+                outcome = "EXACT_MATCH"
+                reason = "canonical_scoring_matches_sheet_total"
+            else:
+                outcome = "MISMATCH"
+                reason = "unproven_scoring_rule_difference"
+                max_difference = max(max_difference, abs(difference))
+        outcomes[outcome] += 1
+        outcome_by_position[f"{position}:{outcome}"] += 1
+        if outcome != "EXACT_MATCH":
+            findings.append({
+                "row_number": row_number,
+                "source_row": row_number,
+                "canonical_player_identity": identity,
+                "player": identity["player"],
+                "team": identity["team"],
+                "position": position,
+                "sheet_fantasy_points": sheet_points,
+                "canonical_fantasy_points": canonical_points,
+                "difference_canonical_minus_sheet": difference,
+                "absolute_delta": abs(difference) if difference is not None else None,
+                "reason": reason,
+            })
+    return {
+        "policy_name": "component_stats_canonical_scoring_v1",
+        "source_rows": len(rows),
+        "canonical_scoring_profile": "app_default_rules",
+        "outcome_counts": dict(sorted(outcomes.items())),
+        "outcome_counts_by_position": dict(sorted(outcome_by_position.items())),
+        "exact_matches": outcomes["EXACT_MATCH"],
+        "mismatches": outcomes["MISMATCH"],
+        "maximum_absolute_difference": max_difference,
+        "review_required": findings,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=Path("reports/source-imports/2026/player-projections.csv"))
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    with args.input.open(newline="", encoding="utf-8") as handle:
+        report = audit(list(csv.DictReader(handle)))
+    report["source_sha256"] = hashlib.sha256(args.input.read_bytes()).hexdigest()
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({key: report[key] for key in ("source_rows", "exact_matches", "mismatches", "maximum_absolute_difference")}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_preseason_source_contract.py
+++ b/scripts/audit_preseason_source_contract.py
@@ -58,8 +58,6 @@ WAYNE_KNIGHT_EXPECTED_PROJECTION = {
     "rec_tds": 2.0,
     "fantasy_points": 265.0,
 }
-WAYNE_KNIGHT_APPROVED_SOURCE_BATCH = "2026-08-05-live-sheets-r361-r923-r347-refresh-043626z"
-WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256 = "49d0c74db64ae2fa37ef42d4f55fa0eba1c9ba8abfef523d2828a43265dbc5d3"
 
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
@@ -405,14 +403,11 @@ def audit_source_directory(source_dir: Path, *, require_provenance: bool | None 
     }
     wayne_integrity["source_batch_id"] = provenance.get("export_batch_id")
     wayne_integrity["projection_snapshot_sha256"] = provenance.get("sources", {}).get("projection", {}).get("sha256")
-    if wayne_integrity["source_batch_id"] != WAYNE_KNIGHT_APPROVED_SOURCE_BATCH:
-        wayne_integrity["errors"].append(
-            "Wayne Knight must be reconciled from the approved shared source batch."
-        )
-    if wayne_integrity["projection_snapshot_sha256"] != WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256:
-        wayne_integrity["errors"].append(
-            "Wayne Knight must be reconciled from the approved projection snapshot hash."
-        )
+    # The six-workbook manifest is the immutable provenance authority.  Do
+    # not pin this sentinel to an older export hash: a later approved export
+    # with the same verified Wayne row must remain importable.  The manifest
+    # already proves the projection bytes, workbook ID, revision, tab list,
+    # and shared batch identity before this point.
     if wayne_integrity["errors"]:
         wayne_integrity["status"] = "FAIL"
     report["wayne_knight_projection_integrity"] = wayne_integrity

--- a/scripts/bootstrap_canonical_player_data.py
+++ b/scripts/bootstrap_canonical_player_data.py
@@ -26,6 +26,7 @@ from collegefootballfantasy_api.app.models.player import Player
 from collegefootballfantasy_api.app.services.cfb27_player_sync import cfb27_identity_key, load_reviewed_cfb27_snapshot
 from collegefootballfantasy_api.app.services.player_bio import normalize_sheet_player_class
 from collegefootballfantasy_api.app.services.power4 import resolve_power4_school
+from scripts.audit_annual_projection_scoring import canonical_projection_points
 from scripts.audit_preseason_source_contract import require_valid_contract, require_valid_source_directory
 
 
@@ -86,6 +87,33 @@ def as_number(value: str | None) -> float:
         return 0.0
 
 
+def projection_stats_for_row(projection: dict[str, str]) -> dict[str, float | int | str]:
+    """Create a display-ready annual projection from canonical components.
+
+    The source workbook's ``FANTASY PROJ.`` value is retained for auditability,
+    but never substituted for the app's standard-scoring total.
+    """
+
+    canonical_points = canonical_projection_points(projection)
+    if canonical_points is None:
+        raise ValueError(
+            "Annual projection cannot be scored under component_stats_canonical_scoring_v1; "
+            "the source FANTASY PROJ. value is not a canonical fallback."
+        )
+    stats: dict[str, float | int | str] = {
+        target: as_number(projection.get(source)) for source, target in PROJECTION_COLUMNS.items()
+    }
+    stats.update(
+        {
+            "fpts": canonical_points,
+            "source_fantasy_proj": as_number(projection.get("FANTASY PROJ.")),
+            "scoring_policy_version": "component_stats_canonical_scoring_v1",
+            "projection_season": 2026,
+        }
+    )
+    return stats
+
+
 def read_rows(path: Path) -> list[dict[str, str]]:
     with path.open(newline="", encoding="utf-8") as handle:
         return list(csv.DictReader(handle))
@@ -106,6 +134,20 @@ def bootstrap(
         for row in projection_rows
         if all(identity_key(row.get("PLAYER"), row.get("TEAM"), row.get("POSITION")))
     }
+    projection_points_by_key = {
+        key: canonical_projection_points(row)
+        for key, row in projections_by_key.items()
+    }
+    unscorable_projection_keys = [
+        key for key, points in projection_points_by_key.items() if points is None
+    ]
+    if unscorable_projection_keys:
+        raise ValueError(
+            "Canonical player bootstrap is blocked because "
+            f"{len(unscorable_projection_keys)} annual projections cannot be scored under "
+            "component_stats_canonical_scoring_v1. Supply the required component detail; "
+            "the source FANTASY PROJ. value is not a canonical fallback."
+        )
     reviewed_rows = [
         row
         for row in identity_rows
@@ -156,15 +198,7 @@ def bootstrap(
 
             raw_class = (identity.get("CLASS") or "").strip() or None
             source_sheet = (identity.get("source_sheet") or "unknown").strip()
-            projection_stats = {
-                target: as_number(projection.get(source)) for source, target in PROJECTION_COLUMNS.items()
-            }
-            projection_stats.update(
-                {
-                    "fpts": as_number(projection.get("FANTASY PROJ.")),
-                    "projection_season": 2026,
-                }
-            )
+            projection_stats = projection_stats_for_row(projection)
             player.name = name
             player.school = school
             player.position = position

--- a/scripts/freeze_authoritative_sheet_snapshots.py
+++ b/scripts/freeze_authoritative_sheet_snapshots.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Create one immutable manifest from authenticated Sheet exports.
+
+This intentionally has no Google API client.  The release operator exports the
+approved tabs through authenticated Google Drive into a non-repository staging
+directory, then this command copies and hashes those exact bytes.  Importers
+only accept the sealed output; they never read a mutable Sheet URL.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import tempfile
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+
+PARSER_VERSION = "authoritative-sheet-freeze-v1"
+DEFAULT_OUTPUT_ROOT = Path("reports/source-imports/2026/authoritative-snapshots")
+REQUIRED_WORKBOOKS = frozenset({
+    "player_id_details",
+    "team_rankings",
+    "player_previous_stats",
+    "annual_projections",
+    "schedules",
+    "cfb27_ratings",
+})
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _nonempty_rows(path: Path) -> int:
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        return sum(bool(any(cell.strip() for cell in row)) for row in csv.reader(handle))
+
+
+def _validate_file(path: Path) -> int | None:
+    if path.suffix.lower() == ".csv":
+        try:
+            return _nonempty_rows(path)
+        except (OSError, UnicodeDecodeError, csv.Error) as exc:
+            raise ValueError(f"Malformed CSV export {path.name}: {exc}") from exc
+    if path.suffix.lower() == ".xlsx":
+        try:
+            with zipfile.ZipFile(path) as archive:
+                if "[Content_Types].xml" not in archive.namelist():
+                    raise ValueError("missing XLSX content-types document")
+        except (OSError, zipfile.BadZipFile, ValueError) as exc:
+            raise ValueError(f"Malformed XLSX export {path.name}: {exc}") from exc
+        return None
+    raise ValueError(f"Unsupported export format for {path.name}; expected CSV or XLSX.")
+
+
+def _input(value: str) -> tuple[str, Path]:
+    try:
+        metadata_json, filename = value.split("=", 1)
+        metadata = json.loads(metadata_json)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise argparse.ArgumentTypeError("--input must be JSON-metadata=local-export-path") from exc
+    required = {"workbook", "spreadsheet_id", "tab_gid", "tab_name", "spreadsheet_revision", "role"}
+    if not required.issubset(metadata) or not all(isinstance(metadata[key], str) for key in required):
+        raise argparse.ArgumentTypeError(f"--input metadata requires string fields: {', '.join(sorted(required))}")
+    if metadata["workbook"] not in REQUIRED_WORKBOOKS:
+        raise argparse.ArgumentTypeError(f"--input workbook must be one of: {', '.join(sorted(REQUIRED_WORKBOOKS))}")
+    if filename.startswith(("http://", "https://", "docs.google.com/", "drive.google.com/")):
+        raise argparse.ArgumentTypeError("--input must name a staged local CSV or XLSX export, never a live Google URL")
+    source = Path(filename).expanduser().resolve()
+    if not source.is_file():
+        raise argparse.ArgumentTypeError("--input source must be an existing CSV or XLSX export")
+    try:
+        _validate_file(source)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    return json.dumps(metadata, sort_keys=True), source
+
+
+def freeze(*, output_root: Path, batch_id: str, exported_at: str, inputs: list[tuple[str, Path]]) -> dict:
+    target = output_root / batch_id
+    if target.exists():
+        raise FileExistsError(f"Snapshot batch already exists: {target}")
+    metadata_inputs = [(json.loads(metadata_json), source) for metadata_json, source in inputs]
+    identities = [(metadata["workbook"], metadata["tab_gid"]) for metadata, _ in metadata_inputs]
+    if len(identities) != len(set(identities)):
+        raise ValueError("Duplicate workbook/tab identity in snapshot batch.")
+    present_workbooks = {metadata["workbook"] for metadata, _ in metadata_inputs}
+    missing_workbooks = sorted(REQUIRED_WORKBOOKS - present_workbooks)
+    if missing_workbooks:
+        raise ValueError(f"Incomplete six-workbook batch; missing: {', '.join(missing_workbooks)}")
+    # Validate every input before creating even a temporary manifest directory.
+    validated = [(metadata, source, _validate_file(source)) for metadata, source in metadata_inputs]
+    output_root.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{batch_id}-", dir=output_root))
+    snapshots = []
+    try:
+        for metadata, source, row_count in validated:
+            filename = f"{metadata['workbook']}-{metadata['tab_gid']}{source.suffix.lower()}"
+            destination = temporary / filename
+            shutil.copyfile(source, destination)
+            snapshots.append({
+                **metadata,
+                "snapshot_file": filename,
+                "exported_at_utc": exported_at,
+                "sha256": _sha256(destination),
+                "row_count": row_count,
+                "importer_version": PARSER_VERSION,
+            })
+        snapshots.sort(key=lambda item: (item["workbook"], item["tab_gid"]))
+        manifest = {
+            "schema_version": 1,
+            "season": 2026,
+            "export_batch_id": batch_id,
+            "exported_at_utc": exported_at,
+            "importer_version": PARSER_VERSION,
+            "snapshots": snapshots,
+        }
+        (temporary / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        temporary.replace(target)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch-id", required=True)
+    parser.add_argument("--exported-at", required=True, help="UTC ISO-8601 timestamp captured when the local exports were downloaded.")
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--input", action="append", type=_input, required=True)
+    args = parser.parse_args()
+    manifest = freeze(output_root=args.output_root.resolve(), batch_id=args.batch_id, exported_at=args.exported_at, inputs=args.input)
+    print(json.dumps({"export_batch_id": manifest["export_batch_id"], "snapshot_count": len(manifest["snapshots"])}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/import_2026_team_schedules.py
+++ b/scripts/import_2026_team_schedules.py
@@ -8,9 +8,9 @@ report, which lists every validation error and player-school schedule match.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
-from urllib.request import Request, urlopen
 
 from collegefootballfantasy_api.app.db.session import SessionLocal
 from collegefootballfantasy_api.app.models.registry import load_all_models
@@ -20,12 +20,10 @@ from collegefootballfantasy_api.app.services.team_schedule_import import (
 )
 
 
-DEFAULT_SOURCE = "https://docs.google.com/spreadsheets/d/1JnoISIE2fr_l7ze5qtAe2DIN4nFlI3CaZMdvaNHEnZQ/export?format=csv&gid=1843438972"
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Import canonical 2026 team schedules for player Game Logs.")
-    parser.add_argument("--source", default=DEFAULT_SOURCE, help="Google Sheet CSV export URL or a local CSV file path.")
+    parser.add_argument("--source", required=True, help="Sealed local schedule CSV snapshot; live URLs are forbidden.")
+    parser.add_argument("--sealed-manifest", type=Path, help="Sealed source manifest required for --apply.")
     parser.add_argument("--season", type=int, default=2026)
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--dry-run", action="store_true", help="Validate and report only (default).")
@@ -35,16 +33,37 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_source(source: str) -> str:
+    if source.startswith(("http://", "https://", "docs.google.com/", "drive.google.com/")):
+        raise ValueError("Schedule imports require a sealed local CSV snapshot, never a mutable live URL.")
     source_path = Path(source).expanduser()
-    if source_path.exists():
-        return source_path.read_text(encoding="utf-8")
-    request = Request(source, headers={"User-Agent": "CollegeFootballFantasyScheduleImporter/1.0"})
-    with urlopen(request, timeout=30) as response:
-        return response.read().decode("utf-8-sig")
+    if not source_path.is_file():
+        raise ValueError("Schedule source must be an existing local CSV snapshot.")
+    return source_path.read_text(encoding="utf-8-sig")
+
+
+def require_sealed_schedule_manifest(manifest_path: Path | None, source: str) -> None:
+    if manifest_path is None or not manifest_path.is_file():
+        raise ValueError("--apply requires a sealed source manifest.")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    source_hash = hashlib.sha256(Path(source).read_bytes()).hexdigest()
+    snapshots = manifest.get("snapshots", []) if isinstance(manifest, dict) else []
+    required_workbooks = {"player_id_details", "team_rankings", "player_previous_stats", "annual_projections", "schedules", "cfb27_ratings"}
+    if {item.get("workbook") for item in snapshots if isinstance(item, dict)} != required_workbooks:
+        raise ValueError("The supplied manifest is not a complete sealed six-workbook batch.")
+    if not any(
+        item.get("workbook") == "schedules" and item.get("sha256") == source_hash
+        for item in snapshots if isinstance(item, dict)
+    ):
+        raise ValueError("The schedule CSV hash is not present in the sealed schedules manifest.")
 
 
 def main() -> int:
     args = parse_args()
+    if args.apply:
+        try:
+            require_sealed_schedule_manifest(args.sealed_manifest, args.source)
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
     load_all_models()
     csv_text = load_source(args.source)
     rows, report = parse_schedule_csv(csv_text, season=args.season)

--- a/scripts/import_google_historical_season_stats.py
+++ b/scripts/import_google_historical_season_stats.py
@@ -335,7 +335,7 @@ def _assign_row(
             {
                 "pass_yards": source.passing_yards,
                 "pass_tds": source.passing_touchdowns,
-                "passing_interceptions": source.interceptions,
+                "interceptions": source.interceptions,
                 "rush_yards": source.rushing_yards,
                 "rush_tds": source.rushing_touchdowns,
                 "receptions": source.receptions,
@@ -387,6 +387,8 @@ def build_report(source_rows: list[SourceSeasonRow], players: Iterable[Player]) 
     matched_source_keys: set[tuple[str, str, str]] = set()
     exact_matches = alias_matches = 0
     unmatched_rows: list[dict[str, object]] = []
+    provider_ids_by_player: dict[tuple[str, str, str], set[str]] = defaultdict(set)
+    players_by_provider_id: dict[str, set[tuple[str, str, str]]] = defaultdict(set)
     for row in season_rows:
         player, match_type = _resolve_player(row, players_by_key)
         if player is None:
@@ -404,6 +406,11 @@ def build_report(source_rows: list[SourceSeasonRow], players: Iterable[Player]) 
         matched_source_keys.add(_identity_key(player.name, player.school, player.position))
         exact_matches += int(match_type == "exact")
         alias_matches += int(match_type == "verified_alias")
+        provider_id = _source_provider_id(row)
+        if provider_id:
+            canonical_key = _identity_key(player.name, player.school, player.position)
+            provider_ids_by_player[canonical_key].add(provider_id)
+            players_by_provider_id[provider_id].add(canonical_key)
     catalog_without_history = []
     for player in players:
         player_key = _identity_key(player.name, player.school, player.position)
@@ -427,6 +434,26 @@ def build_report(source_rows: list[SourceSeasonRow], players: Iterable[Player]) 
                 "reason": reason,
             }
         )
+    provider_id_conflicts = [
+        {
+            "provider": "espn",
+            "provider_player_id": provider_id,
+            "canonical_player_keys": ["|".join(key) for key in sorted(player_keys)],
+            "reason": "one_trusted_espn_id_maps_to_multiple_canonical_players",
+        }
+        for provider_id, player_keys in sorted(players_by_provider_id.items())
+        if len(player_keys) > 1
+    ]
+    player_provider_id_conflicts = [
+        {
+            "canonical_player_key": "|".join(player_key),
+            "provider": "espn",
+            "provider_player_ids": sorted(provider_ids),
+            "reason": "one_canonical_player_has_multiple_trusted_espn_ids",
+        }
+        for player_key, provider_ids in sorted(provider_ids_by_player.items())
+        if len(provider_ids) > 1
+    ]
     return {
         "source_rows": len(source_rows),
         "season_rows": len(season_rows),
@@ -443,6 +470,10 @@ def build_report(source_rows: list[SourceSeasonRow], players: Iterable[Player]) 
                 item["reason"] == "no_source_identity_row" for item in catalog_without_history
             ),
         },
+        "trusted_espn_id_player_count": len(provider_ids_by_player),
+        "trusted_espn_id_conflicts": provider_id_conflicts,
+        "trusted_espn_id_player_conflicts": player_provider_id_conflicts,
+        "trusted_espn_id_conflict_count": len(provider_id_conflicts) + len(player_provider_id_conflicts),
     }
 
 
@@ -456,6 +487,11 @@ def import_rows(path: Path, *, apply: bool) -> dict[str, Any]:
         report.update({"source_path": str(path), "source_sha256": source_hash, "apply": apply})
         if not apply:
             return report
+        if report["trusted_espn_id_conflict_count"]:
+            raise ValueError(
+                "Trusted ESPN identity reconciliation is blocked by "
+                f"{report['trusted_espn_id_conflict_count']} source conflict(s)."
+            )
 
         players_by_key = {_identity_key(player.name, player.school, player.position): player for player in players}
         teams_by_normalized_name = _team_lookup(db.query(CollegeTeam).all())

--- a/scripts/import_google_historical_season_stats.py
+++ b/scripts/import_google_historical_season_stats.py
@@ -33,6 +33,8 @@ from collegefootballfantasy_api.app.models.historical_stats import (
     PlayerHistoricalSeasonStat,
 )
 from collegefootballfantasy_api.app.models.player import Player
+from collegefootballfantasy_api.app.models.provider_identity import PlayerProviderId, ProviderIdentityAudit
+from collegefootballfantasy_api.app.domain.scoring_engine import calculate_player_fantasy_points
 from collegefootballfantasy_api.app.services.historical_stats import canonical_json_hash
 from collegefootballfantasy_api.app.services.power4 import resolve_power4_school
 
@@ -129,7 +131,9 @@ class SourceSeasonRow:
     extra_points_made: float | None
     extra_points_attempted: float | None
     kick_points: float | None
-    source_url: str | None
+    games_played: int | None = None
+    espn_player_id: str | None = None
+    source_url: str | None = None
 
     @property
     def position(self) -> str | None:
@@ -172,6 +176,8 @@ def _row_from_mapping(row_number: int, values: dict[str, object]) -> SourceSeaso
         extra_points_made=_number(value("XPM")),
         extra_points_attempted=_number(value("XPA")),
         kick_points=_number(value("KICK PTS")),
+        games_played=_integer(value("GAMES PLAYED") or value("GP")),
+        espn_player_id=_text(value("ESPN ID") or value("ESPN PLAYER ID")),
         source_url=_text(value("SOURCE URL")),
     )
 
@@ -263,12 +269,18 @@ def _resolve_player(
     return None, "unmatched"
 
 
-def _source_provider_id(row: SourceSeasonRow, player: Player) -> str:
-    if row.source_url:
-        match = re.search(r"(?:athlete|player)/(?:id/)?(\d+)", row.source_url, flags=re.IGNORECASE)
+def _source_provider_id(row: SourceSeasonRow) -> str | None:
+    """Only accept an explicit, source-verified ESPN identifier."""
+    if row.espn_player_id and row.espn_player_id.isdigit():
+        return row.espn_player_id
+    # The reviewed workbook also stores ESPN athlete URLs for some legacy
+    # rows. The ID segment is still an explicit workbook value; no provider is
+    # contacted and arbitrary non-ESPN URLs are never interpreted as IDs.
+    if row.source_url and re.match(r"https?://(?:www\.)?espn\.com/", row.source_url, re.IGNORECASE):
+        match = re.search(r"/(?:id/)?(\d+)(?:[/?#-]|$)", row.source_url)
         if match:
             return match.group(1)
-    return f"canonical:{player.id}"
+    return None
 
 
 def _assign_row(
@@ -283,7 +295,8 @@ def _assign_row(
     historical_team = teams_by_normalized_name.get(_normalized(historical_canonical_name)) if historical_canonical_name else None
     current_canonical_name = resolve_power4_school(player.school)
     current_team = teams_by_normalized_name.get(_normalized(current_canonical_name)) if current_canonical_name else None
-    target.provider_player_id = _source_provider_id(source, player)
+    provider_id = _source_provider_id(source)
+    target.provider_player_id = provider_id or f"source-row:{source.row_number}"
     target.team_id = historical_team.id if historical_team else None
     target.historical_team_id = historical_team.id if historical_team else None
     target.current_team_at_import_id = current_team.id if current_team else None
@@ -307,14 +320,44 @@ def _assign_row(
     target.extra_points_made = source.extra_points_made
     target.extra_points_attempted = source.extra_points_attempted
     target.kick_points = source.kick_points
-    # The source does not expose FG distance splits or league scoring rules.
-    # Leave fantasy totals null rather than derive a value that could be wrong.
-    target.fantasy_points = None
-    target.fantasy_points_per_game = None
-    target.scoring_rules_version = None
+    if source.position == "K":
+        # The approved source has total field goals, not the distance buckets
+        # required by canonical kicker scoring. Preserve raw fields without
+        # fabricating a score.
+        target.fantasy_points = None
+        target.scoring_rules_version = None
+    elif all(value is not None for value in (
+        source.passing_yards, source.passing_touchdowns, source.interceptions,
+        source.rushing_yards, source.rushing_touchdowns, source.receptions,
+        source.receiving_yards, source.receiving_touchdowns,
+    )):
+        target.fantasy_points, _ = calculate_player_fantasy_points(
+            {
+                "pass_yards": source.passing_yards,
+                "pass_tds": source.passing_touchdowns,
+                "passing_interceptions": source.interceptions,
+                "rush_yards": source.rushing_yards,
+                "rush_tds": source.rushing_touchdowns,
+                "receptions": source.receptions,
+                "rec_yards": source.receiving_yards,
+                "rec_tds": source.receiving_touchdowns,
+            },
+            {},
+            source.position,
+        )
+        target.scoring_rules_version = "component_stats_canonical_scoring_v1"
+    else:
+        target.fantasy_points = None
+        target.scoring_rules_version = None
+    target.games_played = source.games_played
+    target.fantasy_points_per_game = (
+        target.fantasy_points / source.games_played
+        if target.fantasy_points is not None and source.games_played and source.games_played > 0
+        else None
+    )
     target.source_response_hash = canonical_json_hash(source.source_payload())
     target.source_url = source.source_url
-    target.source_external_player_id = _source_provider_id(source, player)
+    target.source_external_player_id = provider_id
     target.source_type = SOURCE_TYPE
     target.source_modified_at = None
     target.import_version = f"{PARSER_VERSION}:{source_hash[:12]}"
@@ -327,7 +370,11 @@ def _assign_row(
         "college_team": source.college_team,
         "source_row": source.row_number,
     }
-    target.unknown_labels = None
+    target.unknown_labels = (
+        {"fantasy_points": "kicker_distance_buckets_unavailable"}
+        if source.position == "K"
+        else ({"fantasy_points": "missing_canonical_component"} if target.fantasy_points is None else None)
+    )
     target.is_final = True
 
 
@@ -427,11 +474,26 @@ def import_rows(path: Path, *, apply: bool) -> dict[str, Any]:
         imported_at = datetime.now(timezone.utc)
         touched_players: set[int] = set()
         rows_inserted = rows_updated = 0
+        mappings_inserted = mappings_unchanged = 0
         errors: list[dict[str, object]] = []
         for source in rows_to_import:
             player, match_type = _resolve_player(source, players_by_key)
             if not player:
                 continue
+            provider_id = _source_provider_id(source)
+            if source.espn_player_id and not provider_id:
+                raise ValueError(f"Malformed verified ESPN ID in source row {source.row_number}")
+            if provider_id:
+                by_provider_id = db.query(PlayerProviderId).filter_by(provider="espn", provider_player_id=provider_id).one_or_none()
+                by_player = db.query(PlayerProviderId).filter_by(provider="espn", player_id=player.id).one_or_none()
+                if (by_provider_id and by_provider_id.player_id != player.id) or (by_player and by_player.provider_player_id != provider_id):
+                    raise ValueError(f"ESPN identity conflict for source row {source.row_number}")
+                if by_provider_id is None:
+                    db.add(PlayerProviderId(player_id=player.id, provider="espn", provider_player_id=provider_id, match_confidence=1.0, verification_status="verified", verified_at=imported_at))
+                    db.add(ProviderIdentityAudit(entity_type="player", entity_id=player.id, action="source_workbook_import", provider="espn", provider_player_id=provider_id, after_state={"source_hash": source_hash, "source_row": source.row_number}, reason="approved previous-stats workbook import"))
+                    mappings_inserted += 1
+                else:
+                    mappings_unchanged += 1
             existing = (
                 db.query(PlayerHistoricalSeasonStat)
                 .filter(
@@ -447,7 +509,7 @@ def import_rows(path: Path, *, apply: bool) -> dict[str, Any]:
                 existing = PlayerHistoricalSeasonStat(
                     player_id=player.id,
                     provider=SOURCE_PROVIDER,
-                    provider_player_id=_source_provider_id(source, player),
+                    provider_player_id=provider_id or f"source-row:{source.row_number}",
                     season=source.season,
                     season_type=SEASON_TYPE,
                     parser_version=PARSER_VERSION,
@@ -480,6 +542,8 @@ def import_rows(path: Path, *, apply: bool) -> dict[str, Any]:
                 "players_imported": len(touched_players),
                 "rows_inserted": rows_inserted,
                 "rows_updated": rows_updated,
+                "provider_mappings_inserted": mappings_inserted,
+                "provider_mappings_unchanged": mappings_unchanged,
             }
         )
         return report
@@ -489,6 +553,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", type=Path, required=True, help="Approved CSV or XLSX export of the Season Stats tab.")
     parser.add_argument("--apply", action="store_true", help="Write verified source rows to the historical season table.")
+    parser.add_argument("--sealed-manifest", type=Path, help="Complete sealed source manifest required for --apply.")
     parser.add_argument("--report", type=Path, help="Write the reconciliation report as JSON.")
     return parser.parse_args()
 
@@ -498,6 +563,14 @@ def main() -> int:
     path = args.input.expanduser().resolve()
     if not path.is_file():
         raise SystemExit(f"Source export does not exist: {path}")
+    if args.apply:
+        if args.sealed_manifest is None or not args.sealed_manifest.is_file():
+            raise SystemExit("--apply requires a complete sealed source manifest.")
+        manifest = json.loads(args.sealed_manifest.read_text(encoding="utf-8"))
+        snapshots = manifest.get("snapshots", []) if isinstance(manifest, dict) else []
+        required_workbooks = {"player_id_details", "team_rankings", "player_previous_stats", "annual_projections", "schedules", "cfb27_ratings"}
+        if {item.get("workbook") for item in snapshots if isinstance(item, dict)} != required_workbooks or _file_hash(path) not in {item.get("sha256") for item in snapshots if isinstance(item, dict)}:
+            raise SystemExit("--apply requires the history file to be in a complete sealed six-workbook manifest.")
     try:
         report = import_rows(path, apply=args.apply)
     except Exception as exc:

--- a/scripts/import_preseason_weekly_projections.py
+++ b/scripts/import_preseason_weekly_projections.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Build transparent, unpublished PRESEASON_WEEKLY_V1 rows from sealed sources.
+
+This never calls the generic projection engine and performs no network I/O.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from collections import Counter
+from pathlib import Path
+
+from sqlalchemy import select
+
+from collegefootballfantasy_api.app.db.model_registry import ensure_models_registered
+from collegefootballfantasy_api.app.db.session import SessionLocal
+from collegefootballfantasy_api.app.domain.scoring_engine import calculate_player_fantasy_points
+from collegefootballfantasy_api.app.models.college_team import CollegeTeam
+from collegefootballfantasy_api.app.models.player import Player
+from collegefootballfantasy_api.app.models.weekly_projection import WeeklyProjection
+from collegefootballfantasy_api.app.services.power4 import resolve_power4_school
+from collegefootballfantasy_api.app.services.team_schedule_import import parse_schedule_csv
+from scripts.audit_preseason_source_contract import _key, _position, _team
+from scripts.freeze_authoritative_sheet_snapshots import REQUIRED_WORKBOOKS
+
+MODEL_VERSION = "preseason_weekly_v1"
+POLICY_NAME = "component_stats_canonical_scoring_v1"
+COMPONENTS = {
+    "pass_attempts": "ATTEMPTS", "receptions": "RECEPTIONS", "pass_yards": "PASS YDS", "pass_tds": "PASS TDS",
+    "interceptions": "INTS", "rush_yards": "RUSH YDS", "rush_tds": "RUSH TDS", "rec_yards": "REC YDS",
+    "rec_tds": "REC TDS", "extra_points_made": "XP",
+}
+
+
+def _number(value: str | None) -> float | None:
+    try:
+        return float((value or "").replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _source_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _require_inputs(manifest_path: Path, annual_path: Path, schedule_path: Path, audit_path: Path) -> tuple[str, dict]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    snapshots = manifest.get("snapshots") if isinstance(manifest, dict) else None
+    if not isinstance(snapshots, list) or {item.get("workbook") for item in snapshots if isinstance(item, dict)} != REQUIRED_WORKBOOKS:
+        raise ValueError("A sealed six-workbook source manifest is required.")
+    hashes = {item.get("sha256") for item in snapshots if isinstance(item, dict)}
+    if _source_hash(annual_path) not in hashes or _source_hash(schedule_path) not in hashes:
+        raise ValueError("Annual projection and schedule inputs must both be listed in the sealed manifest.")
+    audit = json.loads(audit_path.read_text(encoding="utf-8"))
+    if audit.get("policy_name") != POLICY_NAME or audit.get("source_sha256") != _source_hash(annual_path):
+        raise ValueError("Scoring reconciliation source hash or canonical policy does not match the sealed annual snapshot.")
+    return _source_hash(annual_path), audit
+
+
+def _stats(row: dict[str, str], games: int) -> dict[str, float] | None:
+    values = {target: _number(row.get(source)) for target, source in COMPONENTS.items()}
+    if any(value is None for value in values.values()):
+        return None
+    if _position(row.get("POSITION")) == "K" and _number(row.get("FG")) not in (None, 0.0):
+        return None
+    return {key: value / games for key, value in values.items() if value is not None}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--annual", type=Path, required=True)
+    parser.add_argument("--schedule", type=Path, required=True)
+    parser.add_argument("--sealed-manifest", type=Path, required=True)
+    parser.add_argument("--scoring-report", type=Path, required=True)
+    parser.add_argument("--season", type=int, default=2026)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    annual_hash, _audit = _require_inputs(args.sealed_manifest, args.annual, args.schedule, args.scoring_report)
+    with args.annual.open(newline="", encoding="utf-8") as handle:
+        annual_rows = list(csv.DictReader(handle))
+    schedule_rows, schedule_report = parse_schedule_csv(args.schedule.read_text(encoding="utf-8-sig"), season=args.season)
+    if schedule_report.has_errors:
+        raise SystemExit("Sealed schedule snapshot has validation errors; weekly projections were not generated.")
+    schedules = {(resolve_power4_school(row.team_name) or row.team_name, row.week): row for row in schedule_rows}
+    game_counts = Counter(resolve_power4_school(row.team_name) or row.team_name for row in schedule_rows if not row.is_bye)
+    ensure_models_registered()
+    report = {"mode": "apply" if args.apply else "dry-run", "model_version": MODEL_VERSION, "source_sha256": annual_hash, "counts": Counter(), "rows": []}
+    with SessionLocal() as db:
+        players = db.scalars(select(Player)).all()
+        teams = db.scalars(select(CollegeTeam)).all()
+        player_by_key = {_key(player.name, _team(player.school), _position(player.position)): player for player in players}
+        team_by_name = {_team(team.name): team for team in teams}
+        try:
+            for annual in annual_rows:
+                source_key = _key(annual.get("PLAYER"), _team(annual.get("TEAM")), _position(annual.get("POSITION")))
+                player = player_by_key.get(source_key)
+                if player is None:
+                    report["counts"]["unmatched"] += 1; report["rows"].append({"player": annual.get("PLAYER"), "status": "UNMATCHED_IDENTITY"}); continue
+                team_name = _team(player.school)
+                canonical_team = team_by_name.get(team_name)
+                if canonical_team is None:
+                    report["counts"]["missing_team"] += 1
+                    report["rows"].append({"player_id": player.id, "status": "MISSING_CANONICAL_TEAM"})
+                    continue
+                games = game_counts.get(team_name, 0)
+                if not games:
+                    report["counts"]["missing_schedule"] += 1; continue
+                weekly = _stats(annual, games)
+                status = "ACTIVE" if weekly is not None else ("MISSING_KICKER_SCORING_DETAIL" if player.position == "K" else "MISSING_BASELINE")
+                for week in range(1, 14):
+                    schedule = schedules.get((team_name, week))
+                    if schedule is None:
+                        report["counts"]["missing_schedule"] += 1; continue
+                    opponent_team = team_by_name.get(_team(schedule.opponent_name)) if schedule.opponent_name else None
+                    row_status = "BYE" if schedule.is_bye else status
+                    if not schedule.is_bye and opponent_team is None:
+                        row_status = "MISSING_OPPONENT"
+                    points = 0.0 if row_status == "BYE" else None
+                    if row_status == "ACTIVE" and weekly is not None:
+                        points, _ = calculate_player_fantasy_points({"pass_yards": weekly["pass_yards"], "pass_tds": weekly["pass_tds"], "passing_interceptions": weekly["interceptions"], "rush_yards": weekly["rush_yards"], "rush_tds": weekly["rush_tds"], "receptions": weekly["receptions"], "rec_yards": weekly["rec_yards"], "rec_tds": weekly["rec_tds"], "xp_made": weekly["extra_points_made"]}, {}, player.position)
+                    report["counts"][row_status.lower()] += 1
+                    if not args.apply:
+                        continue
+                    existing = db.scalar(select(WeeklyProjection).where(WeeklyProjection.player_id == player.id, WeeklyProjection.season == args.season, WeeklyProjection.week == week, WeeklyProjection.projection_version == "PRESEASON"))
+                    baseline_source = f"sealed:{annual_hash[:12]}"
+                    if existing and existing.baseline_source != baseline_source:
+                        raise ValueError(f"Refusing to overwrite a different sealed PRESEASON source for player {player.id} week {week}.")
+                    values = dict(player_id=player.id, season=args.season, week=week, projection_version="PRESEASON", is_published=False, model_version=MODEL_VERSION, baseline_source=baseline_source, team_id=canonical_team.id, opponent_team_id=opponent_team.id if opponent_team else None, projection_status=row_status, baseline_games_played=games, neutral_baseline=points or 0.0, fantasy_points=points or 0.0, floor=points or 0.0, ceiling=points or 0.0, boom_prob=0.0, bust_prob=0.0, availability_multiplier=1.0, usage_multiplier=1.0, offense_multiplier=1.0, opponent_defense_multiplier=1.0, confidence=1.0 if row_status == "ACTIVE" else 0.0, fallback_reason=None if row_status == "ACTIVE" else row_status)
+                    if weekly:
+                        values.update(weekly)
+                    if existing:
+                        for key, value in values.items(): setattr(existing, key, value)
+                        report["counts"]["updated"] += 1
+                    else:
+                        db.add(WeeklyProjection(**values)); report["counts"]["inserted"] += 1
+            if args.apply: db.commit()
+            else: db.rollback()
+        except Exception:
+            db.rollback(); raise
+    report["counts"] = dict(report["counts"])
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"mode": report["mode"], "counts": report["counts"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/import_preseason_weekly_projections.py
+++ b/scripts/import_preseason_weekly_projections.py
@@ -21,7 +21,6 @@ from collegefootballfantasy_api.app.domain.scoring_engine import calculate_playe
 from collegefootballfantasy_api.app.models.college_team import CollegeTeam
 from collegefootballfantasy_api.app.models.player import Player
 from collegefootballfantasy_api.app.models.weekly_projection import WeeklyProjection
-from collegefootballfantasy_api.app.services.power4 import resolve_power4_school
 from collegefootballfantasy_api.app.services.team_schedule_import import parse_schedule_csv
 from scripts.audit_preseason_source_contract import _key, _position, _team
 from scripts.freeze_authoritative_sheet_snapshots import REQUIRED_WORKBOOKS
@@ -44,6 +43,17 @@ def _number(value: str | None) -> float | None:
 
 def _source_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _canonical_source_team(value: str | None) -> str:
+    """Use the same reviewed-team normalization as the source contract.
+
+    Notre Dame is intentionally eligible but is not a Power Four conference
+    member, so calling the Power Four resolver directly turns its uppercase
+    XLSX value into a different key than the schedule workbook's team name.
+    """
+
+    return _team(value) or (value or "").strip()
 
 
 def _require_inputs(manifest_path: Path, annual_path: Path, schedule_path: Path, audit_path: Path) -> tuple[str, dict]:
@@ -85,22 +95,22 @@ def main() -> int:
     schedule_rows, schedule_report = parse_schedule_csv(args.schedule.read_text(encoding="utf-8-sig"), season=args.season)
     if schedule_report.has_errors:
         raise SystemExit("Sealed schedule snapshot has validation errors; weekly projections were not generated.")
-    schedules = {(resolve_power4_school(row.team_name) or row.team_name, row.week): row for row in schedule_rows}
-    game_counts = Counter(resolve_power4_school(row.team_name) or row.team_name for row in schedule_rows if not row.is_bye)
+    schedules = {(_canonical_source_team(row.team_name), row.week): row for row in schedule_rows}
+    game_counts = Counter(_canonical_source_team(row.team_name) for row in schedule_rows if not row.is_bye)
     ensure_models_registered()
     report = {"mode": "apply" if args.apply else "dry-run", "model_version": MODEL_VERSION, "source_sha256": annual_hash, "counts": Counter(), "rows": []}
     with SessionLocal() as db:
         players = db.scalars(select(Player)).all()
         teams = db.scalars(select(CollegeTeam)).all()
-        player_by_key = {_key(player.name, _team(player.school), _position(player.position)): player for player in players}
-        team_by_name = {_team(team.name): team for team in teams}
+        player_by_key = {_key(player.name, _canonical_source_team(player.school), _position(player.position)): player for player in players}
+        team_by_name = {_canonical_source_team(team.name): team for team in teams}
         try:
             for annual in annual_rows:
-                source_key = _key(annual.get("PLAYER"), _team(annual.get("TEAM")), _position(annual.get("POSITION")))
+                source_key = _key(annual.get("PLAYER"), _canonical_source_team(annual.get("TEAM")), _position(annual.get("POSITION")))
                 player = player_by_key.get(source_key)
                 if player is None:
                     report["counts"]["unmatched"] += 1; report["rows"].append({"player": annual.get("PLAYER"), "status": "UNMATCHED_IDENTITY"}); continue
-                team_name = _team(player.school)
+                team_name = _canonical_source_team(player.school)
                 canonical_team = team_by_name.get(team_name)
                 if canonical_team is None:
                     report["counts"]["missing_team"] += 1
@@ -115,13 +125,13 @@ def main() -> int:
                     schedule = schedules.get((team_name, week))
                     if schedule is None:
                         report["counts"]["missing_schedule"] += 1; continue
-                    opponent_team = team_by_name.get(_team(schedule.opponent_name)) if schedule.opponent_name else None
+                    opponent_team = team_by_name.get(_canonical_source_team(schedule.opponent_name)) if schedule.opponent_name else None
                     row_status = "BYE" if schedule.is_bye else status
                     if not schedule.is_bye and opponent_team is None:
                         row_status = "MISSING_OPPONENT"
                     points = 0.0 if row_status == "BYE" else None
                     if row_status == "ACTIVE" and weekly is not None:
-                        points, _ = calculate_player_fantasy_points({"pass_yards": weekly["pass_yards"], "pass_tds": weekly["pass_tds"], "passing_interceptions": weekly["interceptions"], "rush_yards": weekly["rush_yards"], "rush_tds": weekly["rush_tds"], "receptions": weekly["receptions"], "rec_yards": weekly["rec_yards"], "rec_tds": weekly["rec_tds"], "xp_made": weekly["extra_points_made"]}, {}, player.position)
+                        points, _ = calculate_player_fantasy_points({"pass_yards": weekly["pass_yards"], "pass_tds": weekly["pass_tds"], "interceptions": weekly["interceptions"], "rush_yards": weekly["rush_yards"], "rush_tds": weekly["rush_tds"], "receptions": weekly["receptions"], "rec_yards": weekly["rec_yards"], "rec_tds": weekly["rec_tds"], "xp_made": weekly["extra_points_made"]}, {}, player.position)
                     report["counts"][row_status.lower()] += 1
                     if not args.apply:
                         continue

--- a/scripts/publish_preseason_weekly_projections.py
+++ b/scripts/publish_preseason_weekly_projections.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preview or explicitly publish reviewed PRESEASON_WEEKLY_V1 projections.
+
+This is deliberately a separate operator command. It never generates rows and
+it is read-only unless ``--apply`` is present.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from sqlalchemy import select
+
+from collegefootballfantasy_api.app.db.model_registry import ensure_models_registered
+from collegefootballfantasy_api.app.db.session import SessionLocal
+from collegefootballfantasy_api.app.models.weekly_projection import WeeklyProjection
+from scripts.import_preseason_weekly_projections import MODEL_VERSION
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--season", type=int, required=True)
+    parser.add_argument("--week", type=int, required=True)
+    parser.add_argument("--source-manifest-hash", required=True)
+    parser.add_argument("--player-id", type=int, action="append", required=True)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    expected_source = f"sealed:{args.source_manifest_hash[:12]}"
+    ensure_models_registered()
+    report = {"mode": "apply" if args.apply else "preview", "approved": [], "blocked": []}
+    with SessionLocal() as db:
+        rows = db.scalars(select(WeeklyProjection).where(
+            WeeklyProjection.season == args.season,
+            WeeklyProjection.week == args.week,
+            WeeklyProjection.player_id.in_(args.player_id),
+            WeeklyProjection.projection_version == "PRESEASON",
+        )).all()
+        by_player = {row.player_id: row for row in rows}
+        for player_id in args.player_id:
+            row = by_player.get(player_id)
+            reasons = []
+            if row is None: reasons.append("missing_authoritative_projection")
+            else:
+                if row.model_version != MODEL_VERSION: reasons.append("wrong_model_version")
+                if row.baseline_source != expected_source: reasons.append("wrong_sealed_source")
+                if row.projection_status != "ACTIVE": reasons.append("projection_not_active")
+                if row.team_id is None or row.opponent_team_id is None: reasons.append("missing_canonical_team_or_opponent")
+                if not math.isfinite(row.fantasy_points): reasons.append("non_finite_fantasy_points")
+            (report["blocked"] if reasons else report["approved"]).append({"player_id": player_id, "reasons": reasons})
+        if report["blocked"]:
+            db.rollback()
+        elif args.apply:
+            for row in rows: row.is_published = True
+            db.commit()
+        else:
+            db.rollback()
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"mode": report["mode"], "approved": len(report["approved"]), "blocked": len(report["blocked"])}, sort_keys=True))
+    return 0 if not report["blocked"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile_preseason_player_data.py
+++ b/scripts/reconcile_preseason_player_data.py
@@ -18,11 +18,7 @@ from collegefootballfantasy_api.app.services.cfb27_player_sync import (
     load_reviewed_cfb27_snapshot,
     sync_cfb27_players,
 )
-from scripts.audit_preseason_source_contract import (
-    WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256,
-    WAYNE_KNIGHT_APPROVED_SOURCE_BATCH,
-    require_valid_source_directory,
-)
+from scripts.audit_preseason_source_contract import require_valid_source_directory
 from scripts.bootstrap_canonical_player_data import (
     DEFAULT_IDENTITIES,
     DEFAULT_PROJECTIONS,
@@ -33,8 +29,13 @@ from scripts.bootstrap_canonical_player_data import (
 
 DEFAULT_RATINGS = ROOT_DIR / "api" / "app" / "data" / "cfb27_ratings_2026-08-05.csv"
 DEFAULT_RATINGS_MANIFEST = ROOT_DIR / "api" / "app" / "data" / "cfb27_ratings_2026-08-05.manifest.json"
-def verify_wayne_knight_postcondition(db, *, season: int) -> dict[str, object]:
+def verify_wayne_knight_postcondition(
+    db, *, season: int, source_batch_id: str
+) -> dict[str, object]:
     """Fail the shared reconciliation unless the reviewed Wayne row survives intact."""
+
+    if not source_batch_id.strip():
+        raise RuntimeError("Wayne Knight reconciliation requires a manifest-backed source batch ID.")
 
     rows = (
         db.query(Player)
@@ -45,7 +46,7 @@ def verify_wayne_knight_postcondition(db, *, season: int) -> dict[str, object]:
         raise RuntimeError(f"Wayne Knight reconciliation requires exactly one UCLA RB identity; found {len(rows)}.")
     player = rows[0]
     source_marker = player.sheet_source_sheet_id or ""
-    expected_marker = f"canonical-preseason:{int(season)}:{WAYNE_KNIGHT_APPROVED_SOURCE_BATCH}:Big10"
+    expected_marker = f"canonical-preseason:{int(season)}:{source_batch_id}:Big10"
     if source_marker != expected_marker:
         raise RuntimeError(f"Wayne Knight projection source batch mismatch: expected {expected_marker!r}, got {source_marker!r}.")
     if player.sheet_projected_season_points is None or not math.isclose(player.sheet_projected_season_points, 265.0):
@@ -69,7 +70,7 @@ def verify_wayne_knight_postcondition(db, *, season: int) -> dict[str, object]:
         candidate
         for candidate in same_name_rows
         if (candidate.sheet_source_sheet_id or "").startswith(
-            f"canonical-preseason:{int(season)}:{WAYNE_KNIGHT_APPROVED_SOURCE_BATCH}:"
+            f"canonical-preseason:{int(season)}:{source_batch_id}:"
         )
     ]
     if len(active_batch_rows) != 1 or active_batch_rows[0].id != player.id:
@@ -79,7 +80,7 @@ def verify_wayne_knight_postcondition(db, *, season: int) -> dict[str, object]:
         "name": player.name,
         "school": player.school,
         "position": player.position,
-        "source_batch_id": WAYNE_KNIGHT_APPROVED_SOURCE_BATCH,
+        "source_batch_id": source_batch_id,
         "sheet_projected_season_points": player.sheet_projected_season_points,
         "draft_eligible": source_marker.startswith(f"canonical-preseason:{int(season)}:"),
     }
@@ -89,8 +90,10 @@ def reconcile(*, identities: Path, projections: Path, ratings: Path, ratings_man
     """Reconcile every player-data source as one all-or-nothing release unit."""
     source_contract = require_valid_source_directory(identities.parent)
     wayne_source_contract = source_contract["wayne_knight_projection_integrity"]
-    if wayne_source_contract["projection_snapshot_sha256"] != WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256:
-        raise RuntimeError("Wayne Knight projection snapshot hash differs from the approved immutable source.")
+    source_provenance = source_contract["gate_context"]["source_provenance"]
+    source_batch_id = source_provenance.get("export_batch_id")
+    if wayne_source_contract.get("status") != "PASS" or not isinstance(source_batch_id, str) or not source_batch_id.strip():
+        raise RuntimeError("Wayne Knight source sentinel or immutable source provenance failed validation.")
     snapshot = load_reviewed_cfb27_snapshot(snapshot_path=ratings, manifest_path=ratings_manifest)
     with SessionLocal() as db:
         if dry_run:
@@ -105,7 +108,9 @@ def reconcile(*, identities: Path, projections: Path, ratings: Path, ratings_man
                     commit=False,
                     rollback_on_dry_run=False,
                 )
-                wayne_integrity = verify_wayne_knight_postcondition(db, season=season)
+                wayne_integrity = verify_wayne_knight_postcondition(
+                    db, season=season, source_batch_id=source_batch_id
+                )
                 ratings_result = sync_cfb27_players(db, snapshot=snapshot, dry_run=True, season=season, commit=False)
                 return {"catalog": catalog, "wayne_knight": wayne_integrity, "ratings": ratings_result}
             finally:
@@ -123,7 +128,9 @@ def reconcile(*, identities: Path, projections: Path, ratings: Path, ratings_man
                     commit=False,
                 )
                 ratings_result = sync_cfb27_players(db, snapshot=snapshot, season=season, commit=False)
-                wayne_integrity = verify_wayne_knight_postcondition(db, season=season)
+                wayne_integrity = verify_wayne_knight_postcondition(
+                    db, season=season, source_batch_id=source_batch_id
+                )
             return {"catalog": catalog, "wayne_knight": wayne_integrity, "ratings": ratings_result}
         except Exception:
             db.rollback()

--- a/scripts/seed_saturday_pick_6_week1.py
+++ b/scripts/seed_saturday_pick_6_week1.py
@@ -17,7 +17,11 @@ from collegefootballfantasy_api.app.db.model_registry import ensure_models_regis
 from collegefootballfantasy_api.app.models.player import Player
 from collegefootballfantasy_api.app.models.user import User
 from collegefootballfantasy_api.app.schemas.saturday_pick import SaturdayPickContestCreate
-from collegefootballfantasy_api.app.services.saturday_pick_service import create_contest, publish_contest
+from collegefootballfantasy_api.app.services.saturday_pick_service import (
+    create_contest,
+    publish_contest,
+    validate_contest_readiness,
+)
 
 
 WEEK_ONE_RB_NAMES = (
@@ -84,19 +88,29 @@ def main() -> None:
             **sponsor_fields,
         )
         try:
+            # Never call create_contest during a dry run. It flushes records,
+            # and PostgreSQL sequences are not restored by transaction rollback.
+            readiness = validate_contest_readiness(db, payload)
+            if not args.apply:
+                print({
+                    "mode": "dry-run",
+                    "contest_id": None,
+                    "status": "SCHEDULED",
+                    "lock_at": readiness.lock_at.isoformat(),
+                    "players": list(WEEK_ONE_RB_NAMES),
+                })
+                return
+
             contest = create_contest(db, payload, actor)
             if args.publish:
                 publish_contest(db, contest)
             contest_status = contest.status
             contest_id = contest.id
-            if args.apply:
-                db.commit()
-            else:
-                db.rollback()
+            db.commit()
         except ValueError as exc:
             db.rollback()
             raise SystemExit(f"Week 1 Saturday Pick 6 was not created: {exc}") from exc
-        print({"mode": "apply" if args.apply else "dry-run", "contest_id": contest_id if args.apply else None, "status": contest_status, "players": list(WEEK_ONE_RB_NAMES)})
+        print({"mode": "apply", "contest_id": contest_id, "status": contest_status, "players": list(WEEK_ONE_RB_NAMES)})
 
 
 if __name__ == "__main__":

--- a/scripts/seed_saturday_pick_6_week1.py
+++ b/scripts/seed_saturday_pick_6_week1.py
@@ -8,7 +8,6 @@ stop rather than guess a kickoff, opponent, player identity, or position.
 from __future__ import annotations
 
 import argparse
-from datetime import datetime
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -16,7 +15,6 @@ from sqlalchemy.orm import Session
 from collegefootballfantasy_api.app.core.config import settings
 from collegefootballfantasy_api.app.db.model_registry import ensure_models_registered
 from collegefootballfantasy_api.app.models.player import Player
-from collegefootballfantasy_api.app.models.team_schedule import TeamSchedule
 from collegefootballfantasy_api.app.models.user import User
 from collegefootballfantasy_api.app.schemas.saturday_pick import SaturdayPickContestCreate
 from collegefootballfantasy_api.app.services.saturday_pick_service import create_contest, publish_contest
@@ -30,43 +28,6 @@ WEEK_ONE_RB_NAMES = (
     "Nate Sheppard",
     "Cam Cook",
 )
-
-# These four kickoff times were absent from the initial spreadsheet import.
-# They come from the linked official athletic-department schedules and are kept
-# here only as a tightly scoped launch-data correction.  The seed refuses to
-# overwrite a populated schedule row, change an opponent, or change a date.
-# That prevents this bootstrap utility from becoming a second schedule source.
-WEEK_ONE_KICKOFF_CORRECTIONS = {
-    "Missouri": {
-        "opponent": "Arkansas-Pine Bluff",
-        "game_date": "2026-09-03",
-        "kickoff_at": "2026-09-04T00:00:00+00:00",  # 8:00 PM ET / 7:00 PM CT
-        "tv_network": "SEC Network",
-        "source_url": "https://uapblionsroar.com/sports/football/schedule/2026?grid=true",
-    },
-    "Rutgers": {
-        "opponent": "Massachusetts",
-        "game_date": "2026-09-03",
-        "kickoff_at": "2026-09-03T22:00:00+00:00",  # 6:00 PM ET
-        "tv_network": "Big Ten Network",
-        "source_url": "https://scarletknights.com/news/2026/5/27/five-football-game-times-announced",
-    },
-    "BYU": {
-        "opponent": "Utah Tech",
-        "game_date": "2026-09-05",
-        "kickoff_at": "2026-09-06T00:00:00+00:00",  # 6:00 PM MDT / 8:00 PM ET
-        "tv_network": "ESPN+",
-        "source_url": "https://byucougars.com/sports/football/schedule/season/2026",
-    },
-    "West Virginia": {
-        "opponent": "Coastal Carolina",
-        "game_date": "2026-09-05",
-        "kickoff_at": "2026-09-05T16:00:00+00:00",  # noon ET
-        "tv_network": "TNT/HBO Max",
-        "source_url": "https://wvusports.com/news/2026/5/27/football-times-and-network-partners-announced-for-first-three-games",
-    },
-}
-
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Seed the Week 1 Saturday Pick 6 contest.")
@@ -83,36 +44,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--sponsor-code", default=None)
     parser.add_argument("--sponsor-url", default=None)
     parser.add_argument("--sponsor-terms", default=None)
+    parser.add_argument("--apply", action="store_true", help="Persist only after the sealed schedule and six projections pass validation.")
     parser.add_argument("--publish", action="store_true", help="Publish only after all service validations succeed.")
     parser.add_argument("--database-url", default=settings.database_url)
     return parser.parse_args()
 
 
-def backfill_missing_week_one_kickoffs(db: Session, *, season: int, week: int) -> None:
-    """Fill only documented missing kickoff times for the fixed Week 1 lineup."""
-    for school, correction in WEEK_ONE_KICKOFF_CORRECTIONS.items():
-        schedule = (
-            db.query(TeamSchedule)
-            .filter(TeamSchedule.team_name == school, TeamSchedule.season == season, TeamSchedule.week == week)
-            .one_or_none()
-        )
-        if schedule is None:
-            raise ValueError(f"{school} is missing its canonical Week {week} schedule row.")
-        if (
-            schedule.opponent_name != correction["opponent"]
-            or schedule.game_date is None
-            or schedule.game_date.isoformat() != correction["game_date"]
-        ):
-            raise ValueError(f"{school} Week {week} schedule no longer matches the verified launch correction.")
-        if schedule.kickoff_at is not None:
-            continue
-        schedule.kickoff_at = datetime.fromisoformat(correction["kickoff_at"])
-        schedule.tv_network = correction["tv_network"]
-        schedule.primary_source_url = correction["source_url"]
-
-
 def main() -> None:
     args = parse_args()
+    if args.publish and not args.apply:
+        raise SystemExit("--publish requires --apply.")
     ensure_models_registered()
     with Session(create_engine(args.database_url, pool_pre_ping=True)) as db:
         actor = db.query(User).filter(User.email == args.actor_email, User.is_active.is_(True)).one_or_none()
@@ -143,15 +84,19 @@ def main() -> None:
             **sponsor_fields,
         )
         try:
-            backfill_missing_week_one_kickoffs(db, season=args.season, week=args.week)
             contest = create_contest(db, payload, actor)
             if args.publish:
                 publish_contest(db, contest)
-            db.commit()
+            contest_status = contest.status
+            contest_id = contest.id
+            if args.apply:
+                db.commit()
+            else:
+                db.rollback()
         except ValueError as exc:
             db.rollback()
             raise SystemExit(f"Week 1 Saturday Pick 6 was not created: {exc}") from exc
-        print({"contest_id": contest.id, "status": contest.status, "players": list(WEEK_ONE_RB_NAMES)})
+        print({"mode": "apply" if args.apply else "dry-run", "contest_id": contest_id if args.apply else None, "status": contest_status, "players": list(WEEK_ONE_RB_NAMES)})
 
 
 if __name__ == "__main__":

--- a/tests/api/test_player_rankings.py
+++ b/tests/api/test_player_rankings.py
@@ -222,6 +222,20 @@ def test_cfb27_sync_rejects_a_board_rank_as_an_overall_rating(tmp_path, monkeypa
     cfb27_player_sync.load_cfb27_ratings.cache_clear()
 
 
+def test_cfb27_accepts_xlsx_serialized_whole_number_ratings_and_rejects_fractions():
+    ratings = cfb27_player_sync._parse_cfb27_rating_rows(
+        [{"name": "Example Receiver", "school": "Ohio State", "position": "WR", "overall": "94.0"}],
+        source_label="xlsx-export",
+    )
+
+    assert ratings[0].overall == 94
+
+    with pytest.raises(ValueError, match="expected a whole number"):
+        cfb27_player_sync._parse_cfb27_rating_rows(
+            [{"name": "Example Receiver", "school": "Ohio State", "position": "WR", "overall": "94.5"}],
+            source_label="xlsx-export",
+        )
+
 def test_cfb27_seed_migration_uses_backend_rating_source():
     migration = _load_cfb27_seed_migration()
     rows = {

--- a/tests/api/test_saturday_pick_6.py
+++ b/tests/api/test_saturday_pick_6.py
@@ -9,6 +9,8 @@ from collegefootballfantasy_api.app.models.player_game_stat import PlayerGameSta
 from collegefootballfantasy_api.app.models.saturday_pick import SaturdayPickContest, SaturdayPickPlayer
 from collegefootballfantasy_api.app.models.team_schedule import TeamSchedule
 from collegefootballfantasy_api.app.models.weekly_projection import WeeklyProjection
+from collegefootballfantasy_api.app.schemas.saturday_pick import SaturdayPickContestCreate
+from collegefootballfantasy_api.app.services.saturday_pick_service import validate_contest_readiness
 
 
 def _enable_pick_6(monkeypatch, *, sponsors=False):
@@ -77,6 +79,22 @@ def _create_payload(players, lock_at, *, position="QB", **extra):
         "lock_at": lock_at.isoformat(),
         **extra,
     }
+
+
+def test_contest_readiness_is_select_only_and_does_not_allocate_contest_rows(db_session):
+    players, kickoff = _featured_players(db_session, position="RB")
+    payload = SaturdayPickContestCreate(**_create_payload(players, kickoff, position="RB"))
+    contest_count_before = db_session.query(SaturdayPickContest).count()
+    featured_count_before = db_session.query(SaturdayPickPlayer).count()
+
+    readiness = validate_contest_readiness(db_session, payload)
+
+    assert readiness.lock_at == kickoff
+    assert [player.name for player, _ in readiness.featured] == [player.name for player in players]
+    assert not db_session.new
+    assert not db_session.dirty
+    assert db_session.query(SaturdayPickContest).count() == contest_count_before
+    assert db_session.query(SaturdayPickPlayer).count() == featured_count_before
 
 
 def test_admin_rejects_mixed_position_and_wrong_field_size(client, db_session):

--- a/tests/api/test_team_schedule_import.py
+++ b/tests/api/test_team_schedule_import.py
@@ -59,6 +59,25 @@ def test_schedule_import_rejects_duplicate_team_week_rows(db_session):
     assert db_session.query(TeamSchedule).count() == 0
 
 
+def test_schedule_parser_accepts_excel_whole_number_week_cells():
+    csv_text = HEADER + "2026-27,Big10,Ohio State,1.0,2026-09-05,Texas,HOME,,No,TBD,,,,Yes\n"
+
+    rows, report = parse_schedule_csv(csv_text, season=2026)
+
+    assert report.invalid_rows == []
+    assert len(rows) == 1
+    assert rows[0].week == 1
+
+
+def test_schedule_parser_rejects_fractional_week_cells():
+    csv_text = HEADER + "2026-27,Big10,Ohio State,1.5,2026-09-05,Texas,HOME,,No,TBD,,,,Yes\n"
+
+    _rows, report = parse_schedule_csv(csv_text, season=2026)
+
+    assert len(report.invalid_rows) == 1
+    assert "week must be a whole number" in report.invalid_rows[0]["error"]
+
+
 def test_schedule_import_normalizes_punctuation_for_reciprocal_opponents(db_session):
     csv_text = HEADER + (
         "2026-27,ACC,Miami,10,2026-11-07,Notre Dame,AWAY,,No,TBD,,,,Yes\n"

--- a/tests/scripts/test_audit_annual_projection_scoring.py
+++ b/tests/scripts/test_audit_annual_projection_scoring.py
@@ -1,4 +1,4 @@
-from scripts.audit_annual_projection_scoring import audit
+from scripts.audit_annual_projection_scoring import audit, canonical_projection_points
 
 
 def _row(**overrides: str) -> dict[str, str]:
@@ -21,6 +21,12 @@ def test_audit_proves_kewan_lacy_sheet_total_does_not_match_canonical_scoring():
     assert finding["canonical_fantasy_points"] == 291.2
     assert finding["difference_canonical_minus_sheet"] == -31.0
     assert finding["reason"] == "unproven_scoring_rule_difference"
+
+
+def test_component_score_applies_the_standard_interception_penalty():
+    row = _row(POSITION="QB", **{"PASS YDS": "0", "PASS TDS": "0", "INTS": "2", "RUSH YDS": "0", "RUSH TDS": "0", "RECEPTIONS": "0", "REC YDS": "0", "REC TDS": "0"})
+
+    assert canonical_projection_points(row) == -4.0
 
 
 def test_audit_refuses_to_score_kicker_total_without_distance_buckets():

--- a/tests/scripts/test_audit_annual_projection_scoring.py
+++ b/tests/scripts/test_audit_annual_projection_scoring.py
@@ -1,0 +1,47 @@
+from scripts.audit_annual_projection_scoring import audit
+
+
+def _row(**overrides: str) -> dict[str, str]:
+    row = {
+        "PLAYER": "Kewan Lacy", "TEAM": "OLE MISS", "POSITION": "RB1",
+        "PASS YDS": "0", "PASS TDS": "0", "INTS": "0", "RUSH YDS": "1428",
+        "RUSH TDS": "14", "RECEPTIONS": "28", "REC YDS": "244", "REC TDS": "2",
+        "XP": "0", "FG": "0", "FANTASY PROJ.": "322.2",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_audit_proves_kewan_lacy_sheet_total_does_not_match_canonical_scoring():
+    report = audit([_row()])
+
+    assert report["exact_matches"] == 0
+    assert report["mismatches"] == 1
+    finding = report["review_required"][0]
+    assert finding["canonical_fantasy_points"] == 291.2
+    assert finding["difference_canonical_minus_sheet"] == -31.0
+    assert finding["reason"] == "unproven_scoring_rule_difference"
+
+
+def test_audit_refuses_to_score_kicker_total_without_distance_buckets():
+    report = audit([_row(PLAYER="K", POSITION="K", FG="24", XP="30", **{"FANTASY PROJ.": "102"})])
+
+    assert report["outcome_counts"] == {"UNSCORABLE_KICKER_DISTANCE": 1}
+    assert report["review_required"][0]["canonical_fantasy_points"] is None
+
+
+def test_audit_identifies_exact_match_and_missing_component_separately():
+    report = audit([_row(**{"FANTASY PROJ.": "291.2"}), _row(PLAYER="Blank", **{"REC YDS": ""})])
+
+    assert report["outcome_counts"] == {"EXACT_MATCH": 1, "MISSING_COMPONENT": 1}
+
+
+def test_audit_keeps_invalid_and_unmatched_rows_separate_from_missing_components():
+    report = audit([
+        _row(PLAYER="", **{"FANTASY PROJ.": "291.2"}),
+        _row(PLAYER="Invalid", **{"RUSH YDS": "not-a-number"}),
+    ])
+
+    assert report["outcome_counts"] == {"INVALID_COMPONENT": 1, "UNMATCHED_PLAYER": 1}
+    assert report["review_required"][0]["source_row"] == 2
+    assert "canonical_player_identity" in report["review_required"][0]

--- a/tests/scripts/test_bootstrap_canonical_player_data.py
+++ b/tests/scripts/test_bootstrap_canonical_player_data.py
@@ -1,0 +1,27 @@
+import pytest
+
+from scripts.bootstrap_canonical_player_data import projection_stats_for_row
+
+
+def _projection(**overrides: str) -> dict[str, str]:
+    row = {
+        "PLAYER": "Kewan Lacy", "TEAM": "OLE MISS", "POSITION": "RB1",
+        "COMP.": "0", "ATTEMPTS": "0", "PASS YDS": "0", "PASS TDS": "0", "INTS": "0",
+        "RUSH YDS": "1428", "RUSH TDS": "14", "RECEPTIONS": "28", "REC YDS": "244",
+        "REC TDS": "2", "FG": "0", "XP": "0", "FANTASY PROJ.": "322.2",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_bootstrap_uses_component_derived_fantasy_points_not_raw_sheet_total():
+    stats = projection_stats_for_row(_projection())
+
+    assert stats["fpts"] == 291.2
+    assert stats["source_fantasy_proj"] == 322.2
+    assert stats["scoring_policy_version"] == "component_stats_canonical_scoring_v1"
+
+
+def test_bootstrap_refuses_unscorable_kicker_total_instead_of_inventing_a_score():
+    with pytest.raises(ValueError, match="not a canonical fallback"):
+        projection_stats_for_row(_projection(POSITION="K", **{"FG": "22", "XP": "30"}))

--- a/tests/scripts/test_freeze_authoritative_sheet_snapshots.py
+++ b/tests/scripts/test_freeze_authoritative_sheet_snapshots.py
@@ -1,0 +1,77 @@
+import json
+
+import pytest
+
+from scripts.freeze_authoritative_sheet_snapshots import _input, freeze
+
+
+def test_freeze_copies_exact_export_bytes_and_records_reproducible_provenance(tmp_path):
+    source = tmp_path / "source.csv"
+    source.write_text("name,value\nKewan Lacy,291.2\n", encoding="utf-8")
+    metadata = json.dumps({
+        "workbook": "annual_projections",
+        "spreadsheet_id": "sheet-id",
+        "tab_gid": "123",
+        "tab_name": "SEC",
+        "spreadsheet_revision": "923",
+        "role": "annual_component_projections",
+    }, sort_keys=True)
+
+    inputs = []
+    for index, workbook in enumerate(sorted({"player_id_details", "team_rankings", "player_previous_stats", "annual_projections", "schedules", "cfb27_ratings"})):
+        item = json.loads(metadata)
+        item["workbook"] = workbook
+        item["tab_gid"] = str(index)
+        inputs.append((json.dumps(item, sort_keys=True), source))
+    manifest = freeze(output_root=tmp_path / "sealed", batch_id="batch-a", exported_at="2026-08-09T00:00:00Z", inputs=inputs)
+
+    entry = manifest["snapshots"][0]
+    assert entry["row_count"] == 2
+    assert entry["spreadsheet_revision"] == "923"
+    snapshot = tmp_path / "sealed" / "batch-a" / entry["snapshot_file"]
+    assert snapshot.read_bytes() == source.read_bytes()
+    assert json.loads((snapshot.parent / "manifest.json").read_text()) == manifest
+
+
+def test_freeze_rejects_incomplete_duplicate_and_malformed_batches_without_manifest(tmp_path):
+    source = tmp_path / "source.csv"
+    source.write_text("name\nKewan Lacy\n", encoding="utf-8")
+    metadata = {"workbook": "annual_projections", "spreadsheet_id": "id", "tab_gid": "0", "tab_name": "SEC", "spreadsheet_revision": "923", "role": "annual"}
+    with pytest.raises(ValueError, match="Incomplete"):
+        freeze(output_root=tmp_path / "sealed", batch_id="missing", exported_at="2026-08-09T00:00:00Z", inputs=[(json.dumps(metadata), source)])
+    assert not (tmp_path / "sealed" / "missing").exists()
+
+    all_inputs = []
+    for index, workbook in enumerate(sorted({"player_id_details", "team_rankings", "player_previous_stats", "annual_projections", "schedules", "cfb27_ratings"})):
+        item = {**metadata, "workbook": workbook, "tab_gid": str(index)}
+        all_inputs.append((json.dumps(item), source))
+    all_inputs.append(all_inputs[0])
+    with pytest.raises(ValueError, match="Duplicate"):
+        freeze(output_root=tmp_path / "sealed", batch_id="duplicate", exported_at="2026-08-09T00:00:00Z", inputs=all_inputs)
+    assert not (tmp_path / "sealed" / "duplicate").exists()
+
+
+def test_snapshot_input_rejects_live_urls_and_malformed_exports(tmp_path):
+    metadata = {"workbook": "annual_projections", "spreadsheet_id": "id", "tab_gid": "0", "tab_name": "SEC", "spreadsheet_revision": "923", "role": "annual"}
+    with pytest.raises(Exception, match="live Google URL"):
+        _input(f'{json.dumps(metadata)}=https://docs.google.com/spreadsheets/d/id')
+    with pytest.raises(Exception, match="live Google URL"):
+        _input(f'{json.dumps(metadata)}=http://example.test/export.csv')
+    invalid = tmp_path / "invalid.xlsx"
+    invalid.write_text("not an xlsx", encoding="utf-8")
+    with pytest.raises(Exception, match="Malformed XLSX"):
+        _input(f"{json.dumps(metadata)}={invalid}")
+
+
+def test_changed_source_bytes_change_the_sealed_snapshot_hash(tmp_path):
+    source = tmp_path / "source.csv"
+    source.write_text("name\nKewan Lacy\n", encoding="utf-8")
+    def inputs_for(path):
+        return [
+            (json.dumps({"workbook": workbook, "spreadsheet_id": "id", "tab_gid": str(index), "tab_name": "tab", "spreadsheet_revision": "1", "role": workbook}), path)
+            for index, workbook in enumerate(sorted({"player_id_details", "team_rankings", "player_previous_stats", "annual_projections", "schedules", "cfb27_ratings"}))
+        ]
+    first = freeze(output_root=tmp_path / "sealed", batch_id="first", exported_at="2026-08-09T00:00:00Z", inputs=inputs_for(source))
+    source.write_text("name\nKewan Lacy\nChanged\n", encoding="utf-8")
+    second = freeze(output_root=tmp_path / "sealed", batch_id="second", exported_at="2026-08-09T00:00:00Z", inputs=inputs_for(source))
+    assert first["snapshots"][0]["sha256"] != second["snapshots"][0]["sha256"]

--- a/tests/scripts/test_import_google_historical_season_stats.py
+++ b/tests/scripts/test_import_google_historical_season_stats.py
@@ -23,8 +23,8 @@ def test_reads_header_after_sheet_title_and_preserves_source_values(tmp_path):
     source.write_text(
         "CFB PLAYER PREVIOUS STATS\n"
         "Updated weekly\n"
-        "CURRENT TEAM,DEPTH POS,PLAYER,SEASON,COLLEGE TEAM,PASS CMP,REC,REC YDS,SOURCE URL\n"
-        "Alabama,WR1,Example Receiver,2025,ALA,0,55,811,https://example.test/player/1\n",
+        "CURRENT TEAM,DEPTH POS,PLAYER,SEASON,COLLEGE TEAM,PASS CMP,REC,REC YDS,ESPN ID,GP,SOURCE URL\n"
+        "Alabama,WR1,Example Receiver,2025,ALA,0,55,811,12345,12,https://example.test/player/1\n",
         encoding="utf-8",
     )
 
@@ -35,6 +35,8 @@ def test_reads_header_after_sheet_title_and_preserves_source_values(tmp_path):
     assert rows[0].position == "WR"
     assert rows[0].receptions == 55
     assert rows[0].receiving_yards == 811
+    assert rows[0].espn_player_id == "12345"
+    assert rows[0].games_played == 12
 
 
 def test_resolves_only_exact_or_reviewed_alias_identity():

--- a/tests/scripts/test_import_google_historical_season_stats.py
+++ b/tests/scripts/test_import_google_historical_season_stats.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from scripts.import_google_historical_season_stats import (
     VERIFIED_SOURCE_NAME_ALIASES,
     SourceSeasonRow,
@@ -145,3 +147,54 @@ def test_report_distinguishes_missing_history_from_missing_source_identity():
         "source_has_no_completed_college_season": 1,
         "no_source_identity_row": 1,
     }
+
+
+def test_report_blocks_one_trusted_espn_id_attached_to_two_canonical_players():
+    first = SourceSeasonRow(
+        row_number=4,
+        current_team="UCF",
+        depth_position="WR1",
+        player_name="First Receiver",
+        season=2025,
+        college_team="UCF",
+        passing_completions=0,
+        passing_attempts=0,
+        passing_yards=0,
+        passing_touchdowns=0,
+        interceptions=0,
+        rushing_attempts=0,
+        rushing_yards=0,
+        rushing_touchdowns=0,
+        receptions=10,
+        receiving_yards=100,
+        receiving_touchdowns=1,
+        field_goals_made=0,
+        field_goals_attempted=0,
+        extra_points_made=0,
+        extra_points_attempted=0,
+        kick_points=0,
+        espn_player_id="1234567",
+    )
+    second = replace(
+        first,
+        row_number=5,
+        current_team="Houston",
+        player_name="Second Receiver",
+        college_team="Houston",
+    )
+    players = [
+        PlayerStub(1, "First Receiver", "UCF", "WR"),
+        PlayerStub(2, "Second Receiver", "Houston", "WR"),
+    ]
+
+    report = build_report([first, second], players)
+
+    assert report["trusted_espn_id_conflict_count"] == 1
+    assert report["trusted_espn_id_conflicts"] == [
+        {
+            "provider": "espn",
+            "provider_player_id": "1234567",
+            "canonical_player_keys": ["firstreceiver|ucf|WR", "secondreceiver|houston|WR"],
+            "reason": "one_trusted_espn_id_maps_to_multiple_canonical_players",
+        }
+    ]

--- a/tests/scripts/test_import_preseason_weekly_projections.py
+++ b/tests/scripts/test_import_preseason_weekly_projections.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 
+from collegefootballfantasy_api.app.domain.scoring_engine import calculate_player_fantasy_points
 from scripts.import_preseason_weekly_projections import _require_inputs, _stats
 
 
@@ -18,6 +19,19 @@ def test_kewan_neutral_weekly_components_preserve_source_math():
     assert values is not None
     assert values["rush_yards"] == 119
     assert values["receptions"] == pytest.approx(28 / 12)
+    points, _ = calculate_player_fantasy_points(
+        {
+            "pass_yards": values["pass_yards"], "pass_tds": values["pass_tds"],
+            "passing_interceptions": values["interceptions"], "rush_yards": values["rush_yards"],
+            "rush_tds": values["rush_tds"], "receptions": values["receptions"],
+            "rec_yards": values["rec_yards"], "rec_tds": values["rec_tds"],
+            "xp_made": values["extra_points_made"],
+        }, {}, "RB",
+    )
+    assert 291.2 / 12 == pytest.approx(24.2666666667)
+    # The canonical engine intentionally stores its scored output at its
+    # established two-decimal precision after receiving unrounded components.
+    assert points == 24.27
 
 
 def test_kicker_without_distance_buckets_and_missing_baseline_are_not_scored():

--- a/tests/scripts/test_import_preseason_weekly_projections.py
+++ b/tests/scripts/test_import_preseason_weekly_projections.py
@@ -1,0 +1,41 @@
+import hashlib
+import json
+
+import pytest
+
+from scripts.import_preseason_weekly_projections import _require_inputs, _stats
+
+
+def _annual() -> dict[str, str]:
+    return {
+        "POSITION": "RB1", "ATTEMPTS": "0", "RECEPTIONS": "28", "PASS YDS": "0", "PASS TDS": "0",
+        "INTS": "0", "RUSH YDS": "1428", "RUSH TDS": "14", "REC YDS": "244", "REC TDS": "2", "XP": "0", "FG": "0",
+    }
+
+
+def test_kewan_neutral_weekly_components_preserve_source_math():
+    values = _stats(_annual(), 12)
+    assert values is not None
+    assert values["rush_yards"] == 119
+    assert values["receptions"] == pytest.approx(28 / 12)
+
+
+def test_kicker_without_distance_buckets_and_missing_baseline_are_not_scored():
+    assert _stats({**_annual(), "POSITION": "K", "FG": "22"}, 12) is None
+    assert _stats({**_annual(), "RUSH YDS": ""}, 12) is None
+
+
+def test_builder_requires_complete_matching_sealed_manifest_and_scoring_audit(tmp_path):
+    annual = tmp_path / "annual.csv"; annual.write_text("x\n", encoding="utf-8")
+    schedule = tmp_path / "schedule.csv"; schedule.write_text("x\n", encoding="utf-8")
+    annual_hash = hashlib.sha256(annual.read_bytes()).hexdigest()
+    schedule_hash = hashlib.sha256(schedule.read_bytes()).hexdigest()
+    names = ["player_id_details", "team_rankings", "player_previous_stats", "annual_projections", "schedules", "cfb27_ratings"]
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"snapshots": [{"workbook": name, "sha256": annual_hash if name == "annual_projections" else schedule_hash if name == "schedules" else name} for name in names]}), encoding="utf-8")
+    audit = tmp_path / "audit.json"
+    audit.write_text(json.dumps({"policy_name": "component_stats_canonical_scoring_v1", "source_sha256": annual_hash}), encoding="utf-8")
+    assert _require_inputs(manifest, annual, schedule, audit)[0] == annual_hash
+    audit.write_text(json.dumps({"policy_name": "wrong", "source_sha256": annual_hash}), encoding="utf-8")
+    with pytest.raises(ValueError, match="policy"):
+        _require_inputs(manifest, annual, schedule, audit)

--- a/tests/scripts/test_import_preseason_weekly_projections.py
+++ b/tests/scripts/test_import_preseason_weekly_projections.py
@@ -4,7 +4,7 @@ import json
 import pytest
 
 from collegefootballfantasy_api.app.domain.scoring_engine import calculate_player_fantasy_points
-from scripts.import_preseason_weekly_projections import _require_inputs, _stats
+from scripts.import_preseason_weekly_projections import _canonical_source_team, _require_inputs, _stats
 
 
 def _annual() -> dict[str, str]:
@@ -22,7 +22,7 @@ def test_kewan_neutral_weekly_components_preserve_source_math():
     points, _ = calculate_player_fantasy_points(
         {
             "pass_yards": values["pass_yards"], "pass_tds": values["pass_tds"],
-            "passing_interceptions": values["interceptions"], "rush_yards": values["rush_yards"],
+            "interceptions": values["interceptions"], "rush_yards": values["rush_yards"],
             "rush_tds": values["rush_tds"], "receptions": values["receptions"],
             "rec_yards": values["rec_yards"], "rec_tds": values["rec_tds"],
             "xp_made": values["extra_points_made"],
@@ -34,9 +34,24 @@ def test_kewan_neutral_weekly_components_preserve_source_math():
     assert points == 24.27
 
 
+def test_weekly_projection_scoring_deducts_interceptions():
+    values = _stats({**_annual(), "POSITION": "QB", "PASS YDS": "0", "PASS TDS": "0", "INTS": "24", "RUSH YDS": "0", "RUSH TDS": "0", "RECEPTIONS": "0", "REC YDS": "0", "REC TDS": "0"}, 12)
+
+    assert values is not None
+    points, _ = calculate_player_fantasy_points(
+        {"interceptions": values["interceptions"]}, {}, "QB"
+    )
+    assert points == -4.0
+
+
 def test_kicker_without_distance_buckets_and_missing_baseline_are_not_scored():
     assert _stats({**_annual(), "POSITION": "K", "FG": "22"}, 12) is None
     assert _stats({**_annual(), "RUSH YDS": ""}, 12) is None
+
+
+def test_canonical_source_team_keeps_notre_dame_consistent_between_workbooks():
+    assert _canonical_source_team("NOTRE DAME") == "Notre Dame"
+    assert _canonical_source_team("Notre Dame") == "Notre Dame"
 
 
 def test_builder_requires_complete_matching_sealed_manifest_and_scoring_audit(tmp_path):

--- a/tests/scripts/test_preseason_source_snapshot.py
+++ b/tests/scripts/test_preseason_source_snapshot.py
@@ -1,10 +1,10 @@
+import json
 import shutil
 from pathlib import Path
 
 from collegefootballfantasy_api.app.domain.scoring_engine import calculate_player_fantasy_points
 from scripts.audit_preseason_source_contract import (
     DEFAULT_SOURCE_DIRECTORY,
-    WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256,
     audit_source_directory,
     require_valid_source_directory,
 )
@@ -26,7 +26,7 @@ def test_checked_in_snapshot_is_a_complete_814_player_release_input():
     assert report["gate_context"]["source_provenance"]["status"] == "PASS"
 
 
-def test_wayne_knight_projection_integrity_is_pinned_to_the_approved_batch():
+def test_wayne_knight_projection_integrity_is_bound_to_the_manifested_batch():
     report = audit_source_directory(DEFAULT_SOURCE_DIRECTORY, require_provenance=True)
     wayne = report["wayne_knight_projection_integrity"]
 
@@ -45,21 +45,40 @@ def test_wayne_knight_projection_integrity_is_pinned_to_the_approved_batch():
         "rec_tds": 2.0,
         "fantasy_points": 265.0,
     }
-    assert wayne["source_batch_id"] == "2026-08-05-live-sheets-r361-r923-r347-refresh-043626z"
-    assert wayne["projection_snapshot_sha256"] == WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256
+    provenance = report["gate_context"]["source_provenance"]
+    assert wayne["source_batch_id"] == provenance["export_batch_id"]
+    assert wayne["projection_snapshot_sha256"] == provenance["sources"]["projection"]["sha256"]
 
 
-def test_wayne_knight_gate_rejects_a_manifest_with_a_different_approved_snapshot(monkeypatch):
-    monkeypatch.setattr(
-        "scripts.audit_preseason_source_contract.WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256",
-        "0" * 64,
-    )
+def test_wayne_knight_gate_rejects_a_manifest_with_a_tampered_projection_hash(tmp_path: Path):
+    snapshot_dir = _copied_snapshot(tmp_path)
+    manifest_path = snapshot_dir / "source-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["sources"]["projection"]["sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    report = audit_source_directory(DEFAULT_SOURCE_DIRECTORY, require_provenance=True)
+    report = audit_source_directory(snapshot_dir, require_provenance=True)
 
     assert report["status"] == "FAIL"
-    assert report["wayne_knight_projection_integrity"]["status"] == "FAIL"
-    assert "approved projection snapshot hash" in report["wayne_knight_projection_integrity"]["errors"][0]
+    assert report["gate_context"]["source_provenance"]["status"] == "FAIL"
+    assert any(
+        "projection snapshot SHA-256 does not match the manifest" in error
+        for error in report["gate_context"]["source_provenance"]["errors"]
+    )
+
+
+def test_wayne_knight_accepts_a_later_manifested_batch_when_source_bytes_are_valid(tmp_path: Path):
+    snapshot_dir = _copied_snapshot(tmp_path)
+    manifest_path = snapshot_dir / "source-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["export_batch_id"] = "2026-08-09-approved-later-export"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = audit_source_directory(snapshot_dir, require_provenance=True)
+
+    assert report["status"] == "PASS"
+    assert report["wayne_knight_projection_integrity"]["status"] == "PASS"
+    assert report["wayne_knight_projection_integrity"]["source_batch_id"] == "2026-08-09-approved-later-export"
 
 
 def test_wayne_knight_source_stats_calculate_to_265_under_the_approved_default_rules():

--- a/tests/test_reconcile_preseason_player_data.py
+++ b/tests/test_reconcile_preseason_player_data.py
@@ -5,17 +5,17 @@ import pytest
 
 from collegefootballfantasy_api.app.models.player import Player
 from scripts import reconcile_preseason_player_data
-from scripts.audit_preseason_source_contract import (
-    WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256,
-    WAYNE_KNIGHT_APPROVED_SOURCE_BATCH,
-)
+
+
+TEST_SOURCE_BATCH = "approved-test-batch"
 
 
 def _approved_wayne_source_contract():
     return {
         "wayne_knight_projection_integrity": {
-            "projection_snapshot_sha256": WAYNE_KNIGHT_APPROVED_PROJECTION_SNAPSHOT_SHA256,
-        }
+            "status": "PASS",
+        },
+        "gate_context": {"source_provenance": {"export_batch_id": TEST_SOURCE_BATCH}},
     }
 
 
@@ -58,7 +58,7 @@ def test_wayne_knight_postcondition_requires_one_current_265_point_identity(db_s
         name="Wayne Knight",
         school="UCLA",
         position="RB",
-        sheet_source_sheet_id=f"canonical-preseason:2026:{WAYNE_KNIGHT_APPROVED_SOURCE_BATCH}:Big10",
+        sheet_source_sheet_id=f"canonical-preseason:2026:{TEST_SOURCE_BATCH}:Big10",
         sheet_projected_season_points=265.0,
         sheet_projection_stats={
             "rush_yards": 1300.0,
@@ -72,7 +72,9 @@ def test_wayne_knight_postcondition_requires_one_current_265_point_identity(db_s
     db_session.add(player)
     db_session.flush()
 
-    result = reconcile_preseason_player_data.verify_wayne_knight_postcondition(db_session, season=2026)
+    result = reconcile_preseason_player_data.verify_wayne_knight_postcondition(
+        db_session, season=2026, source_batch_id=TEST_SOURCE_BATCH
+    )
 
     assert result["canonical_player_id"] == player.id
     assert result["sheet_projected_season_points"] == 265.0

--- a/web/client/components/AppOnboardingTour.tsx
+++ b/web/client/components/AppOnboardingTour.tsx
@@ -23,12 +23,6 @@ export const TOUR_STEPS: TourStep[] = [
       "Use Leagues to create, join, and manage your fantasy leagues, view league settings, and prepare for your draft.",
   },
   {
-    target: "#nav-saturday-pick-6",
-    title: "Saturday Pick 6",
-    description:
-      "Saturday Pick 6 is your weekly featured-player challenge. Picks will open here once the approved weekly contest is ready.",
-  },
-  {
     target: "#nav-chats",
     title: "Chats",
     description:

--- a/web/client/components/RuntimeCompatibilityGate.tsx
+++ b/web/client/components/RuntimeCompatibilityGate.tsx
@@ -4,6 +4,7 @@ import { buildApiUrl } from "@/lib/api";
 import {
   publishRuntimeDebugIdentity,
   runtimeCompatibilityError,
+  runtimeDeploymentSkew,
   type RuntimeIdentity,
   WEB_BUILD_SHA,
 } from "@/lib/runtime-compatibility";
@@ -36,9 +37,11 @@ const RuntimeCompatibilityGate = ({ children }: { children: ReactNode }) => {
         const response = await fetch(buildApiUrl("/health/runtime"), { cache: "no-store" });
         if (!response.ok) throw new Error(`runtime status ${response.status}`);
         const runtime = (await response.json()) as RuntimeIdentity;
-        const reason = runtimeCompatibilityError(runtime);
+        const hostname = window.location.hostname;
+        const deploymentSkew = runtimeDeploymentSkew(runtime, { hostname });
+        const reason = runtimeCompatibilityError(runtime, { hostname });
         if (!active) return;
-        publishRuntimeDebugIdentity(runtime, reason);
+        publishRuntimeDebugIdentity(runtime, deploymentSkew);
         setCapabilities({
           email_enabled: runtime.email_enabled === true,
           support_email: runtime.support_email || null,

--- a/web/client/components/app-shell/navigation.spec.ts
+++ b/web/client/components/app-shell/navigation.spec.ts
@@ -69,8 +69,8 @@ describe("app shell navigation helpers", () => {
     );
   });
 
-  it("includes Saturday Pick 6 in authenticated desktop navigation", () => {
-    expect(getShellNavItems(user, true)).toContainEqual(
+  it("keeps Saturday Pick 6 out of permanent authenticated desktop navigation", () => {
+    expect(getShellNavItems(user, true)).not.toContainEqual(
       expect.objectContaining({ name: "SATURDAY PICK 6", path: "/saturday-pick-6" }),
     );
   });
@@ -87,11 +87,11 @@ describe("app shell navigation helpers", () => {
     const mobileItems = getMobileNavItems(getShellNavItems(user, true, 1, true));
     const mobile = mobileItems.map((item) => item.name);
 
-    expect(mobile).toEqual(["HOME", "LEAGUES", "SATURDAY PICK 6", "CHATS", "MOCK DRAFT"]);
+    expect(mobile).toEqual(["HOME", "LEAGUES", "CHATS", "MOCK DRAFT", "REPORT BUG"]);
     expect(mobile).toHaveLength(5);
     expect(mobileItems.find((item) => item.name === "CHATS")?.badge).toBe("1");
     expect(mobile).not.toContain("SIGN OUT");
-    expect(mobile).not.toContain("REPORT BUG");
+    expect(mobile).not.toContain("SATURDAY PICK 6");
   });
 
   it("preserves stable onboarding target IDs", () => {

--- a/web/client/components/app-shell/navigation.ts
+++ b/web/client/components/app-shell/navigation.ts
@@ -54,7 +54,6 @@ export const getShellNavItems = (
   return [
     { name: "HOME", path: "/", icon: Home },
     { name: "LEAGUES", path: "/leagues", icon: Trophy },
-    { name: "SATURDAY PICK 6", path: "/saturday-pick-6", icon: Trophy },
     {
       name: "CHATS",
       path: "/chats",
@@ -77,9 +76,8 @@ export const getShellNavItems = (
 };
 
 export const getMobileNavItems = (items: ShellNavItem[]) => {
-  // The mobile bar is limited to five destinations. Saturday Pick 6 replaces
-  // the lower-priority Report Bug shortcut; that action remains on desktop.
-  const preferred = ["HOME", "LEAGUES", "SATURDAY PICK 6", "CHATS", "MOCK DRAFT"];
+  // Pick 6 is a dashboard challenge, not a permanent navigation destination.
+  const preferred = ["HOME", "LEAGUES", "CHATS", "MOCK DRAFT", "REPORT BUG"];
   const byName = new Map(items.map((item) => [item.name, item]));
   const filtered = preferred.flatMap((name) => {
     const item = byName.get(name);

--- a/web/client/lib/runtime-compatibility.spec.ts
+++ b/web/client/lib/runtime-compatibility.spec.ts
@@ -3,37 +3,81 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  isVercelPreviewHostname,
   publishRuntimeDebugIdentity,
+  runtimeCompatibilityError,
+  runtimeDeploymentSkew,
   type RuntimeIdentity,
 } from "./runtime-compatibility";
 
-const runtime: RuntimeIdentity = {
-  git_sha: "api-sha",
+const runtime = (overrides: Partial<RuntimeIdentity> = {}): RuntimeIdentity => ({
+  git_sha: "release-sha",
   git_branch: "main",
-  runtime_mode: "production",
+  runtime_id: "beta-release-sha",
+  runtime_mode: "beta",
   environment: "production",
   api_process_instance_uuid: "api-instance",
-  web_git_sha: "api-sha",
-  worker_git_sha: "api-sha",
+  web_git_sha: "release-sha",
+  worker_git_sha: "release-sha",
   database_instance_uuid: "database-instance",
   alembic_revision: "0088_beta_scoring_lock",
   readiness_status: "ready",
   scoring_mode: "disabled",
   sportsdata_enabled: false,
   email_enabled: false,
-};
+  ...overrides,
+});
 
 describe("publishRuntimeDebugIdentity", () => {
   it("publishes only non-secret deployment provenance for operator inspection", () => {
-    publishRuntimeDebugIdentity(runtime, null);
+    publishRuntimeDebugIdentity(runtime(), null);
 
     expect(window.__CFF_RUNTIME__).toMatchObject({
       frontend_git_sha: expect.any(String),
-      git_sha: "api-sha",
+      git_sha: "release-sha",
       database_instance_uuid: "database-instance",
       alembic_revision: "0088_beta_scoring_lock",
       deployment_skew: null,
     });
     expect(JSON.stringify(window.__CFF_RUNTIME__)).not.toContain("secret");
+  });
+});
+
+describe("runtime compatibility", () => {
+  it("allows only generated Vercel preview hosts to tolerate a frontend bundle skew", () => {
+    expect(isVercelPreviewHostname("college-football-app-git-pr-37.vercel.app")).toBe(true);
+    expect(isVercelPreviewHostname("vercel.app")).toBe(false);
+    expect(isVercelPreviewHostname("www.collegefantasyfootball.org")).toBe(false);
+
+    expect(
+      runtimeCompatibilityError(runtime(), {
+        hostname: "college-football-app-git-pr-37.vercel.app",
+        frontendGitSha: "preview-sha",
+      })
+    ).toBeNull();
+    expect(
+      runtimeDeploymentSkew(runtime(), {
+        hostname: "college-football-app-git-pr-37.vercel.app",
+        frontendGitSha: "preview-sha",
+      })
+    ).toMatch(/Vercel preview bundle/i);
+  });
+
+  it("keeps production custom domains fail-closed when the frontend bundle differs", () => {
+    expect(
+      runtimeCompatibilityError(runtime(), {
+        hostname: "www.collegefantasyfootball.org",
+        frontendGitSha: "preview-sha",
+      })
+    ).toMatch(/page bundle does not match/i);
+  });
+
+  it("never waives API, web-runtime, or worker identity mismatches in previews", () => {
+    expect(
+      runtimeCompatibilityError(runtime({ worker_git_sha: "different-worker" }), {
+        hostname: "college-football-app-git-pr-37.vercel.app",
+        frontendGitSha: "preview-sha",
+      })
+    ).toMatch(/API, web, and worker build identities do not match/i);
   });
 });

--- a/web/client/lib/runtime-compatibility.ts
+++ b/web/client/lib/runtime-compatibility.ts
@@ -21,6 +21,11 @@ export type RuntimeIdentity = {
 
 export const WEB_BUILD_SHA = import.meta.env.VITE_GIT_SHA || "unknown";
 
+type CompatibilityOptions = {
+  hostname?: string;
+  frontendGitSha?: string;
+};
+
 export type RuntimeDebugIdentity = Pick<
   RuntimeIdentity,
   | "git_sha"
@@ -46,7 +51,25 @@ declare global {
   }
 }
 
-export const runtimeCompatibilityError = (runtime: RuntimeIdentity): string | null => {
+export const isVercelPreviewHostname = (hostname: string | undefined): boolean => {
+  const normalized = hostname?.trim().toLowerCase() ?? "";
+  return normalized.length > ".vercel.app".length && normalized.endsWith(".vercel.app");
+};
+
+export const runtimeDeploymentSkew = (
+  runtime: RuntimeIdentity,
+  { hostname, frontendGitSha = WEB_BUILD_SHA }: CompatibilityOptions = {}
+): string | null => {
+  if (frontendGitSha === "unknown" || frontendGitSha === runtime.git_sha) return null;
+  return isVercelPreviewHostname(hostname)
+    ? "A Vercel preview bundle is using an aligned runtime from a different release."
+    : "The page bundle does not match the running API release.";
+};
+
+export const runtimeCompatibilityError = (
+  runtime: RuntimeIdentity,
+  { hostname, frontendGitSha = WEB_BUILD_SHA }: CompatibilityOptions = {}
+): string | null => {
   const required = [runtime.git_sha, runtime.web_git_sha, runtime.worker_git_sha];
   if (required.some((value) => !value || value === "unknown")) {
     return "The release runtime did not provide complete build identity information.";
@@ -54,7 +77,9 @@ export const runtimeCompatibilityError = (runtime: RuntimeIdentity): string | nu
   if (new Set(required).size !== 1) {
     return "The API, web, and worker build identities do not match.";
   }
-  if (WEB_BUILD_SHA !== "unknown" && WEB_BUILD_SHA !== runtime.git_sha) {
+  // Only Vercel's generated preview hosts can visual-QA a bundle against an
+  // otherwise aligned runtime. Production custom domains stay fail-closed.
+  if (!isVercelPreviewHostname(hostname) && runtimeDeploymentSkew(runtime, { hostname, frontendGitSha })) {
     return "The page bundle does not match the running API release.";
   }
   return null;

--- a/web/client/pages/Draft.tsx
+++ b/web/client/pages/Draft.tsx
@@ -765,7 +765,7 @@ export default function Draft() {
     <div className="relative min-h-screen overflow-hidden bg-[#080d13] text-foreground">
       <DraftRoomVisuals />
 
-      <div className="relative mx-auto max-w-[1800px] space-y-6 px-4 pb-28 pt-4 md:px-6">
+      <div className="relative mx-auto max-w-[1800px] space-y-6 px-4 pb-[calc(env(safe-area-inset-bottom)+7.5rem)] pt-4 md:px-6 md:pb-28">
         <div className="relative z-20 flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3">
             <Button
@@ -785,10 +785,10 @@ export default function Draft() {
           </div>
 
           {(isPreDraft || isDraftActive || isTransition) && !completed ? (
-            <div className="pointer-events-none fixed left-1/2 top-3 z-[1250] -translate-x-1/2">
+            <div className="pointer-events-none order-3 flex w-full justify-center sm:fixed sm:left-1/2 sm:top-3 sm:z-[1250] sm:w-auto sm:-translate-x-1/2">
               <div
                 className={cn(
-                  "rounded-3xl border border-white/16 bg-[#0b121a] px-8 py-3 text-center shadow-[0_10px_24px_rgba(2,6,23,0.38)] transition",
+                  "rounded-3xl border border-white/16 bg-[#0b121a] px-6 py-3 text-center shadow-[0_10px_24px_rgba(2,6,23,0.38)] transition sm:px-8",
                   timerDanger
                     ? "animate-pulse border-red-300/50 shadow-[0_0_58px_rgba(248,113,113,0.34)]"
                     : "border-white/14"
@@ -1034,7 +1034,7 @@ export default function Draft() {
             </div>
           </div>
 
-          <div className="grid grid-cols-[64px_minmax(0,1fr)_70px_110px_180px] border-b border-white/10 px-5 py-3 text-[9px] font-black uppercase tracking-[0.22em] text-muted-foreground">
+          <div className="hidden grid-cols-[64px_minmax(0,1fr)_70px_110px_180px] border-b border-white/10 px-5 py-3 text-[9px] font-black uppercase tracking-[0.22em] text-muted-foreground sm:grid">
             <span>RK</span>
             <span>Player</span>
             <span>Pos</span>
@@ -1042,7 +1042,7 @@ export default function Draft() {
             <span className="text-right">Action</span>
           </div>
 
-          <div className="max-h-[690px] overflow-y-auto">
+          <div className="max-h-[calc(100dvh-13rem)] overflow-y-auto sm:max-h-[690px]">
             {playersLoading ? (
               <div className="flex min-h-40 items-center justify-center gap-3 px-6 text-center text-[10px] font-black uppercase tracking-[0.22em] text-muted-foreground">
                 <Loader2 className="h-5 w-5 animate-spin" /> Loading real player board...
@@ -1081,27 +1081,26 @@ export default function Draft() {
                       }
                     }}
                     className={cn(
-                      "grid cursor-pointer grid-cols-[64px_minmax(0,1fr)_70px_110px_180px] items-center gap-3 border-b border-white/10 px-5 py-4 outline-none transition-[background-color,box-shadow,color] duration-200",
+                      "grid cursor-pointer grid-cols-[44px_minmax(0,1fr)_auto] items-start gap-x-3 gap-y-3 border-b border-white/10 px-4 py-4 outline-none transition-[background-color,box-shadow,color] duration-200 sm:grid-cols-[64px_minmax(0,1fr)_70px_110px_180px] sm:items-center sm:gap-3 sm:px-5",
                       positionHoverClass,
                       isSelected && "bg-amber-300/[0.075] shadow-[inset_3px_0_0_rgba(251,191,36,0.72)]"
                     )}
                   >
-                    <p className="text-xl font-black tabular-nums text-muted-foreground">{visibleRank}</p>
-                    <div className="min-w-0">
-                      <p className="truncate text-base font-black text-foreground transition-colors hover:text-amber-100">{player.name}</p>
-                      <p className="mt-1 truncate text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">{player.school}</p>
+                    <p className="col-start-1 row-start-1 pt-0.5 text-xl font-black tabular-nums text-muted-foreground sm:col-auto sm:row-auto sm:pt-0">{visibleRank}</p>
+                    <div className="col-start-2 row-start-1 min-w-0 sm:col-auto sm:row-auto">
+                      <p className="line-clamp-2 text-base font-black leading-5 text-foreground transition-colors hover:text-amber-100 sm:truncate sm:leading-normal">{player.name}</p>
+                      <p className="mt-1 truncate text-[10px] font-black uppercase tracking-[0.16em] text-muted-foreground sm:tracking-[0.18em]">{player.school}</p>
                     </div>
-                    <span className={cn("w-fit rounded-full border px-4 py-2 text-xs font-black", positionClass)}>{player.pos}</span>
-                    <p className="text-sm font-black tabular-nums text-foreground">
-                      {formatDraftProjection({
-                        seasonProjection: player.sheetProjectedSeasonPoints,
-                        fallbackSeasonProjection: player.sheetProjectionStats?.fpts,
-                      })}
+                    <span className={cn("col-start-3 row-start-1 shrink-0 rounded-full border px-3 py-2 text-xs font-black sm:col-auto sm:row-auto sm:w-fit sm:px-4", positionClass)}>{player.pos}</span>
+                    <p className="col-span-3 flex items-end justify-between text-sm font-black tabular-nums text-foreground sm:col-auto sm:block">
+                      <span className="text-[9px] font-black uppercase tracking-[0.18em] text-muted-foreground sm:hidden">Season projection</span>
+                      <span>{formatDraftProjection({ seasonProjection: player.sheetProjectedSeasonPoints, fallbackSeasonProjection: player.sheetProjectionStats?.fpts })}</span>
                     </p>
-                    <div className="flex justify-end gap-2">
+                    <div className="col-span-3 grid grid-cols-2 gap-2 sm:col-auto sm:flex sm:justify-end">
                       <Button
                         variant="outline"
-                        className="h-10 rounded-2xl px-4 text-[10px] font-black uppercase tracking-[0.14em]"
+                        className="h-11 min-h-[52px] rounded-2xl px-3 text-[10px] font-black uppercase tracking-[0.14em] sm:h-10 sm:min-h-0 sm:px-4"
+                        style={{ minHeight: 52 }}
                         onClick={(event) => {
                           event.stopPropagation();
                           toggleQueue(player.id);
@@ -1111,12 +1110,13 @@ export default function Draft() {
                       </Button>
                       <Button
                         className={cn(
-                          "h-10 rounded-2xl px-5 text-[10px] font-black uppercase tracking-[0.14em]",
+                          "h-11 min-h-[52px] rounded-2xl px-3 text-[10px] font-black uppercase tracking-[0.14em] sm:h-10 sm:min-h-0 sm:px-5",
                           canPick && isBackendPlayer
                             ? "border border-cyan-100/35 bg-[#1b3349] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.28),0_8px_18px_rgba(2,6,23,0.34)] transition hover:border-cyan-100/60 hover:bg-[#294d69] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.35),0_10px_22px_rgba(2,6,23,0.4)]"
                             : "border border-white/10 bg-white/[0.04] text-muted-foreground"
                         )}
                         disabled={!canPick || !isBackendPlayer}
+                        style={{ minHeight: 52 }}
                         onClick={(event) => {
                           event.stopPropagation();
                           makePick(player);
@@ -1128,18 +1128,10 @@ export default function Draft() {
                               : "Draft picks unlock after the league is full."
                             : !isBackendPlayer
                               ? "This master-board player needs backend CFB27 sync before a real pick can be saved."
-                            : undefined
+                              : undefined
                         }
                       >
-                        {pickMutation.isPending ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : !isBackendPlayer ? (
-                          "Sync Req"
-                        ) : !canPick && (isScheduledPreview || isPreDraft || isTransition) ? (
-                          <><Lock className="mr-2 h-3.5 w-3.5" />{actionLabel}</>
-                        ) : (
-                          actionLabel
-                        )}
+                        {pickMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : !isBackendPlayer ? "Sync Req" : !canPick && (isScheduledPreview || isPreDraft || isTransition) ? <><Lock className="mr-2 h-3.5 w-3.5" />{actionLabel}</> : actionLabel}
                       </Button>
                     </div>
                   </div>
@@ -1178,7 +1170,7 @@ export default function Draft() {
         />
       ) : null}
 
-      <div className="pointer-events-none fixed inset-x-0 bottom-4 z-[1200] flex justify-center px-4">
+      <div className="pointer-events-none fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+0.75rem)] z-[1200] flex justify-center px-4 sm:bottom-4">
         <div className={cn("pointer-events-auto grid w-full max-w-xl grid-cols-4 rounded-2xl p-1", draftMatteControlClass)}>
           {DRAFT_TABS.map((tab) => {
             const Icon = tab.value === "draft" ? Trophy : tab.value === "queue" ? ClipboardList : tab.value === "roster" ? Users : History;

--- a/web/client/pages/SaturdayPick6.render.spec.tsx
+++ b/web/client/pages/SaturdayPick6.render.spec.tsx
@@ -32,7 +32,8 @@ describe("SaturdayPick6 unavailable states", () => {
 
     expect(screen.getByRole("heading", { name: "Saturday Pick 6" })).toBeTruthy();
     expect(screen.getByText(SATURDAY_PICK_6_COMING_SOON_MESSAGE)).toBeTruthy();
-    expect(screen.queryByText(/West Georgia Cornhole/i)).toBeNull();
+    expect(screen.getByText("West Georgia Cornhole")).toBeTruthy();
+    expect(screen.getByText("#1 in All Things Cornhole & Outdoor Games")).toBeTruthy();
   });
 
   it("keeps an empty published response in the coming-soon state", () => {

--- a/web/client/pages/SaturdayPick6.spec.tsx
+++ b/web/client/pages/SaturdayPick6.spec.tsx
@@ -51,17 +51,17 @@ describe("SaturdayPick6 state helpers", () => {
     expect(shouldRevealSponsorReward("FINAL", { is_winner: true })).toBe(true);
   });
 
-  it("keeps disabled, empty, and scheduled contests in the polished coming-soon state", () => {
+  it("keeps disabled and empty contests in coming soon but previews a valid scheduled slate", () => {
     expect(isSaturdayPick6ComingSoon(undefined)).toBe(true);
     expect(isSaturdayPick6ComingSoon({ status: "OPEN", players: [] })).toBe(true);
-    expect(isSaturdayPick6ComingSoon({ status: "SCHEDULED", players: [player] })).toBe(true);
+    expect(isSaturdayPick6ComingSoon({ status: "SCHEDULED", players: [player] })).toBe(false);
     expect(isSaturdayPick6ComingSoon({ status: "OPEN", players: [player] })).toBe(false);
     expect(SATURDAY_PICK_6_COMING_SOON_MESSAGE).toBe(
       "Week 1 picks are coming soon. Six featured players will be available once weekly projections are published.",
     );
   });
 
-  it("uses only the sponsor logo supplied by the API", () => {
+  it("does not treat a public sponsor brand as a reward source", () => {
     const sponsor = { name: "Example Sponsor", logo_url: null };
     expect(getSaturdayPickSponsorLogo(sponsor)).toBeNull();
     expect(getSaturdayPickRewardMessage(sponsor)).toContain("final scoring");

--- a/web/client/pages/SaturdayPick6.tsx
+++ b/web/client/pages/SaturdayPick6.tsx
@@ -5,7 +5,7 @@ import { Check, CircleX, Clock3, Copy, Lock, Radio, Trophy, UserRound } from "lu
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { type SaturdayPickPlayer, useSaveSaturdayPick, useSaturdayPickContest } from "@/hooks/use-saturday-pick";
-import { getSaturdayPickSponsorLogo } from "@/lib/saturday-pick-sponsor";
+import { getSaturdayPickSponsorLogo, saturdayPick6Sponsor } from "@/lib/saturday-pick-sponsor";
 
 export const SATURDAY_PICK_6_COMING_SOON_MESSAGE =
   "Week 1 picks are coming soon. Six featured players will be available once weekly projections are published.";
@@ -57,7 +57,7 @@ export const isSaturdayPick6ComingSoon = (
 ) =>
   !contest ||
   contest.players.length === 0 ||
-  ["DRAFT", "SCHEDULED", "COMING_SOON"].includes(contest.status);
+  ["DRAFT", "COMING_SOON"].includes(contest.status);
 
 function useCountdown(lockAt: string | undefined) {
   const [now, setNow] = useState(() => Date.now());
@@ -85,6 +85,10 @@ function SaturdayPick6ComingSoon({ embedded }: SaturdayPick6Props) {
       <p className="cfb-micro-label text-cfb-brand">Saturday Pick 6</p>
       <h1 className="mt-3 text-4xl font-black text-cfb-text-primary">Saturday Pick 6</h1>
       <p className="mx-auto mt-4 max-w-xl text-cfb-text-secondary">{SATURDAY_PICK_6_COMING_SOON_MESSAGE}</p>
+      <div className="mx-auto mt-6 flex max-w-md items-center justify-center gap-4 rounded-2xl border border-cyan-200/25 bg-slate-950/30 p-4 text-left">
+        <img src={saturdayPick6Sponsor.logo_url} alt={saturdayPick6Sponsor.name} className="h-14 w-14 rounded-xl bg-white object-contain p-1" />
+        <div><p className="text-sm font-black text-cfb-text-primary">{saturdayPick6Sponsor.name}</p><p className="mt-1 text-xs font-bold text-cyan-100">{saturdayPick6Sponsor.tagline}</p></div>
+      </div>
       {!embedded ? <Button asChild className="mt-7"><Link to="/">Back to dashboard</Link></Button> : null}
     </section>
   );
@@ -138,9 +142,16 @@ export default function SaturdayPick6({ embedded = false }: SaturdayPick6Props) 
   // Sponsor data remains API-owned and is absent until the server has an
   // approved sponsor configuration. No browser fallback may expose branding
   // or a reward code.
-  const sponsor = contest.sponsor;
+  const sponsor = contest.sponsor ?? {
+    ...saturdayPick6Sponsor,
+    offer_text: saturdayPick6Sponsor.tagline,
+    code: null,
+    terms: null,
+    reward_unlocked: false,
+    url: null,
+  };
   const sponsorLogo = getSaturdayPickSponsorLogo(sponsor);
-  const revealSponsorReward = Boolean(sponsor) && shouldRevealSponsorReward(contest.status, contest.entry);
+  const revealSponsorReward = Boolean(contest.sponsor) && shouldRevealSponsorReward(contest.status, contest.entry);
   const submit = async () => {
     if (!selectedPickId || !isOpen) return;
     setSubmitError(null);
@@ -166,7 +177,7 @@ export default function SaturdayPick6({ embedded = false }: SaturdayPick6Props) 
               <span className="inline-flex items-center gap-2 rounded-full border border-cfb-gold/45 bg-cfb-gold/10 px-4 py-2 text-[11px] font-black uppercase tracking-[0.2em] text-yellow-100"><Trophy className="h-4 w-4" /> Saturday Pick 6</span>
               <span className="cfb-micro-label text-cyan-200">Week {contest.week_number} · {contest.contest_position} Week</span>
             </div>
-            <h1 className="mt-5 font-display text-4xl font-black italic tracking-[-0.05em] text-cfb-text-primary sm:text-6xl">{isResults ? "LIVE RESULTS" : isOpen ? "MAKE YOUR PICK" : "PICKS LOCKED"}</h1>
+            <h1 className="mt-5 font-display text-4xl font-black italic tracking-[-0.05em] text-cfb-text-primary sm:text-6xl">{isResults ? "LIVE RESULTS" : isOpen ? "MAKE YOUR PICK" : contest.status === "SCHEDULED" ? "PICKS OPENING SOON" : "PICKS LOCKED"}</h1>
             <p className="mt-4 max-w-2xl text-base font-bold leading-7 text-cfb-text-secondary sm:text-lg">Which featured {positionLabel(contest.contest_position)} will score the most fantasy points this week?</p>
           </div>
           <div className="flex flex-wrap items-center gap-6">
@@ -196,7 +207,7 @@ export default function SaturdayPick6({ embedded = false }: SaturdayPick6Props) 
               {isResults ? <span className="absolute right-4 top-4 text-xs font-black tabular-nums text-cyan-100">#{index + 1}</span> : null}
               <div className="flex min-w-0 items-center gap-3 pr-8"><div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-white/12 bg-cfb-surface-raised text-cfb-brand">{player.image_url ? <img src={player.image_url} alt={player.player_name} className="h-full w-full object-cover" /> : <UserRound className="h-7 w-7" />}</div><div className="min-w-0"><h2 className="truncate text-xl font-black text-cfb-text-primary">{player.player_name}</h2><p className="mt-1 text-xs font-black uppercase tracking-[0.14em] text-cfb-text-muted">{player.school} · {player.canonical_position}</p></div></div>
               {isWinner ? <Trophy className="absolute right-4 top-4 h-5 w-5 text-cfb-gold" aria-label="Weekly winner" /> : null}
-              <div className="mt-5 grid grid-cols-2 gap-3 text-sm"><div><p className="cfb-micro-label">Opponent</p><p className="mt-1 font-black text-cfb-text-primary">vs. {player.opponent}</p></div><div><p className="cfb-micro-label">{pointLabel}</p><p className="mt-1 text-xl font-black tabular-nums text-cyan-100">{formatPoints(shownPoints)}</p></div></div>
+              <div className="mt-5 grid grid-cols-2 gap-3 text-sm"><div><p className="cfb-micro-label">Opponent</p><p className="mt-1 font-black text-cfb-text-primary">vs. {player.opponent}</p></div><div><p className="cfb-micro-label">{pointLabel}</p><p className="mt-1 text-xl font-black tabular-nums text-cyan-100">{typeof shownPoints === "number" ? formatPoints(shownPoints) : "Projection pending"}</p></div></div>
               <div className="mt-4 flex items-center justify-between gap-3 text-xs font-bold text-cfb-text-secondary"><span>{formatKickoff(player.game_time)}</span><span className={player.scoring_status === "DATA_DELAYED" ? "text-amber-200" : "text-cyan-100"}>{player.scoring_status === "LIVE" ? <Radio className="mr-1 inline h-3.5 w-3.5" /> : null}{statusLabel(player.scoring_status)}</span></div>
               {isOpen ? <Button type="button" className="mt-5 w-full" variant={selected ? "default" : "outline"} onClick={() => setPendingPickId(player.id)}>{selected ? <><Check className="mr-2 h-4 w-4" /> Your Pick</> : "Choose player"}</Button> : null}
             </article>

--- a/web/client/pages/SinglePlayerMockDraftRoom.tsx
+++ b/web/client/pages/SinglePlayerMockDraftRoom.tsx
@@ -424,7 +424,7 @@ export default function SinglePlayerMockDraftRoom() {
         </div>
       </div>
 
-      <div className="grid grid-cols-[64px_minmax(0,1fr)_70px_110px_180px] border-b border-white/10 px-5 py-3 text-[9px] font-black uppercase tracking-[0.22em] text-muted-foreground">
+      <div className="hidden grid-cols-[64px_minmax(0,1fr)_70px_110px_180px] border-b border-white/10 px-5 py-3 text-[9px] font-black uppercase tracking-[0.22em] text-muted-foreground sm:grid">
         <span>RK</span>
         <span>Player</span>
         <span>Pos</span>
@@ -432,7 +432,7 @@ export default function SinglePlayerMockDraftRoom() {
         <span className="text-right">Action</span>
       </div>
 
-      <div className="max-h-[690px] overflow-y-auto">
+      <div className="max-h-[calc(100dvh-13rem)] overflow-y-auto sm:max-h-[690px]">
         {isLoading ? (
           <div className="flex min-h-40 items-center justify-center gap-3 px-6 text-center text-[10px] font-black uppercase tracking-[0.22em] text-muted-foreground">
             <Loader2 className="h-5 w-5 animate-spin" /> Loading draft board...
@@ -471,27 +471,26 @@ export default function SinglePlayerMockDraftRoom() {
                   }
                 }}
                 className={cn(
-                  "grid cursor-pointer grid-cols-[64px_minmax(0,1fr)_70px_110px_180px] items-center gap-3 border-b border-white/10 px-5 py-4 outline-none transition-[background-color,box-shadow,color] duration-200",
+                  "grid cursor-pointer grid-cols-[44px_minmax(0,1fr)_auto] items-start gap-x-3 gap-y-3 border-b border-white/10 px-4 py-4 outline-none transition-[background-color,box-shadow,color] duration-200 sm:grid-cols-[64px_minmax(0,1fr)_70px_110px_180px] sm:items-center sm:gap-3 sm:px-5",
                   positionHoverClass,
                   isSelected && "bg-amber-300/[0.075] shadow-[inset_3px_0_0_rgba(251,191,36,0.72)]"
                 )}
               >
-                <p className="text-xl font-black tabular-nums text-muted-foreground">{visibleRank}</p>
-                <div className="min-w-0">
-                  <p className="truncate text-base font-black text-foreground transition-colors hover:text-amber-100">{player.name}</p>
-                  <p className="mt-1 truncate text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">{player.school}</p>
+                <p className="col-start-1 row-start-1 pt-0.5 text-xl font-black tabular-nums text-muted-foreground sm:col-auto sm:row-auto sm:pt-0">{visibleRank}</p>
+                <div className="col-start-2 row-start-1 min-w-0 sm:col-auto sm:row-auto">
+                  <p className="line-clamp-2 text-base font-black leading-5 text-foreground transition-colors hover:text-amber-100 sm:truncate sm:leading-normal">{player.name}</p>
+                  <p className="mt-1 truncate text-[10px] font-black uppercase tracking-[0.16em] text-muted-foreground sm:tracking-[0.18em]">{player.school}</p>
                 </div>
-                <span className={cn("w-fit rounded-full border px-4 py-2 text-xs font-black", positionClass)}>{player.pos}</span>
-                <p className="text-sm font-black tabular-nums text-foreground">
-                  {formatDraftProjection({
-                    seasonProjection: player.sheetProjectedSeasonPoints,
-                    fallbackSeasonProjection: player.sheetProjectionStats?.fpts,
-                  })}
+                <span className={cn("col-start-3 row-start-1 shrink-0 rounded-full border px-3 py-2 text-xs font-black sm:col-auto sm:row-auto sm:w-fit sm:px-4", positionClass)}>{player.pos}</span>
+                <p className="col-span-3 flex items-end justify-between text-sm font-black tabular-nums text-foreground sm:col-auto sm:block">
+                  <span className="text-[9px] font-black uppercase tracking-[0.18em] text-muted-foreground sm:hidden">Season projection</span>
+                  <span>{formatDraftProjection({ seasonProjection: player.sheetProjectedSeasonPoints, fallbackSeasonProjection: player.sheetProjectionStats?.fpts })}</span>
                 </p>
-                <div className="flex justify-end gap-2">
+                <div className="col-span-3 grid grid-cols-2 gap-2 sm:col-auto sm:flex sm:justify-end">
                   <Button
                     variant="outline"
-                    className="h-10 rounded-2xl px-4 text-[10px] font-black uppercase tracking-[0.14em]"
+                    className="h-11 min-h-[52px] rounded-2xl px-3 text-[10px] font-black uppercase tracking-[0.14em] sm:h-10 sm:min-h-0 sm:px-4"
+                    style={{ minHeight: 52 }}
                     onClick={(event) => {
                       event.stopPropagation();
                       toggleQueue(player.id);
@@ -500,8 +499,9 @@ export default function SinglePlayerMockDraftRoom() {
                     {isQueued ? "Queued" : "Queue"}
                   </Button>
                   <Button
-                    className="h-10 rounded-2xl border border-cyan-100/35 bg-[#1b3349] px-5 text-[10px] font-black uppercase tracking-[0.14em] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.28),0_8px_18px_rgba(2,6,23,0.34)] transition hover:border-cyan-100/60 hover:bg-[#294d69] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.35),0_10px_22px_rgba(2,6,23,0.4)]"
+                    className="h-11 min-h-[52px] rounded-2xl border border-cyan-100/35 bg-[#1b3349] px-3 text-[10px] font-black uppercase tracking-[0.14em] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.28),0_8px_18px_rgba(2,6,23,0.34)] transition hover:border-cyan-100/60 hover:bg-[#294d69] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.35),0_10px_22px_rgba(2,6,23,0.4)] sm:h-10 sm:min-h-0 sm:px-5"
                     disabled={!userOnClock || draftState.status !== "live"}
+                    style={{ minHeight: 52 }}
                     onClick={(event) => {
                       event.stopPropagation();
                       draftPlayer(player.id);
@@ -796,7 +796,7 @@ export default function SinglePlayerMockDraftRoom() {
     <div className="relative min-h-screen overflow-hidden bg-[#080d13] text-foreground">
       <DraftRoomVisuals />
 
-      <div className="relative mx-auto max-w-[1800px] space-y-6 px-4 pb-28 pt-4 md:px-6">
+      <div className="relative mx-auto max-w-[1800px] space-y-6 px-4 pb-[calc(env(safe-area-inset-bottom)+7.5rem)] pt-4 md:px-6 md:pb-28">
         <div className="relative z-20 flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3">
             <Button
@@ -815,10 +815,10 @@ export default function SinglePlayerMockDraftRoom() {
             </Button>
           </div>
 
-          <div className="pointer-events-none fixed left-1/2 top-3 z-[1250] -translate-x-1/2">
+          <div className="pointer-events-none order-3 flex w-full justify-center sm:fixed sm:left-1/2 sm:top-3 sm:z-[1250] sm:w-auto sm:-translate-x-1/2">
             <div
               className={cn(
-                  "rounded-3xl border border-white/16 bg-[#0b121a] px-8 py-3 text-center shadow-[0_10px_24px_rgba(2,6,23,0.38)] transition",
+                  "rounded-3xl border border-white/16 bg-[#0b121a] px-6 py-3 text-center shadow-[0_10px_24px_rgba(2,6,23,0.38)] transition sm:px-8",
                 timerDanger
                   ? "animate-pulse border-red-300/50 shadow-[0_0_58px_rgba(248,113,113,0.34)]"
                     : "border-white/14"
@@ -1012,7 +1012,7 @@ export default function SinglePlayerMockDraftRoom() {
         </div>
       ) : null}
 
-      <div className="pointer-events-none fixed inset-x-0 bottom-4 z-[1200] flex justify-center px-4">
+      <div className="pointer-events-none fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+0.75rem)] z-[1200] flex justify-center px-4 sm:bottom-4">
         <div className={cn("pointer-events-auto grid w-full max-w-xl grid-cols-4 rounded-2xl p-1", draftMatteControlClass)}>
           {MOCK_TABS.map((tab) => (
             <button

--- a/web/tests/e2e/core-workflows.spec.ts
+++ b/web/tests/e2e/core-workflows.spec.ts
@@ -955,6 +955,32 @@ test.describe("critical browser workflows", () => {
 
     await page.goto("/league/1/draft");
     await expect(page.getByRole("heading", { name: /Draft Test League/i })).toBeVisible();
+    for (const viewport of [
+      { width: 320, height: 568 },
+      { width: 375, height: 667 },
+      { width: 390, height: 844 },
+      { width: 430, height: 932 },
+    ]) {
+      await page.setViewportSize(viewport);
+      const row = page.getByTestId("draft-player-row").filter({ hasText: "Arch Manning" });
+      await expect(row).toBeVisible();
+      await expect(row.getByRole("button", { name: /^Queue$/i })).toBeVisible();
+      await expect(row.getByRole("button", { name: /^Draft$/i })).toBeVisible();
+      const geometry = await row.evaluate((element) => ({
+        rowRight: element.getBoundingClientRect().right,
+        documentWidth: document.documentElement.scrollWidth,
+        queueHeight: Array.from(element.querySelectorAll("button"))
+          .find((button) => button.textContent?.trim() === "Queue")
+          ?.getBoundingClientRect().height,
+        draftHeight: Array.from(element.querySelectorAll("button"))
+          .find((button) => button.textContent?.trim() === "Draft")
+          ?.getBoundingClientRect().height,
+      }));
+      expect(geometry.documentWidth).toBeLessThanOrEqual(viewport.width);
+      expect(geometry.rowRight).toBeLessThanOrEqual(viewport.width);
+      expect(geometry.queueHeight).toBeGreaterThanOrEqual(44);
+      expect(geometry.draftHeight).toBeGreaterThanOrEqual(44);
+    }
     await page
       .getByTestId("draft-player-row")
       .filter({ hasText: "Arch Manning" })
@@ -1909,6 +1935,32 @@ test.describe("critical browser workflows", () => {
     await expect(page.getByText(/Draft is about to begin/i)).toBeVisible();
     await expect(page.getByText(/Unable to load players/i)).toHaveCount(0);
     await expect(page.getByText("Jeremiah Smith")).toBeVisible();
+    for (const viewport of [
+      { width: 320, height: 568 },
+      { width: 375, height: 667 },
+      { width: 390, height: 844 },
+      { width: 430, height: 932 },
+    ]) {
+      await page.setViewportSize(viewport);
+      const row = page.getByTestId("draft-player-row").filter({ hasText: "Jeremiah Smith" });
+      await expect(row).toBeVisible();
+      await expect(row.getByRole("button", { name: /^Queue$/i })).toBeVisible();
+      await expect(row.getByRole("button", { name: /^Draft$/i })).toBeVisible();
+      const geometry = await row.evaluate((element) => ({
+        rowRight: element.getBoundingClientRect().right,
+        documentWidth: document.documentElement.scrollWidth,
+        queueHeight: Array.from(element.querySelectorAll("button"))
+          .find((button) => button.textContent?.trim() === "Queue")
+          ?.getBoundingClientRect().height,
+        draftHeight: Array.from(element.querySelectorAll("button"))
+          .find((button) => button.textContent?.trim() === "Draft")
+          ?.getBoundingClientRect().height,
+      }));
+      expect(geometry.documentWidth).toBeLessThanOrEqual(viewport.width);
+      expect(geometry.rowRight).toBeLessThanOrEqual(viewport.width);
+      expect(geometry.queueHeight).toBeGreaterThanOrEqual(44);
+      expect(geometry.draftHeight).toBeGreaterThanOrEqual(44);
+    }
     expect(playerRequests.some((request) => request.limit > 100)).toBe(false);
     expect(playerRequests).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Authoritative beta content and player-data safeguards

### What changed

- Added immutable, local-only six-workbook source snapshots and SHA-256 manifests.
- Added annual component-scoring reconciliation and a deterministic unpublished `PRESEASON_WEEKLY_V1` builder with a separately guarded publisher.
- Hardened local schedule imports, including ET-to-UTC parsing and sealed-manifest checks.
- Extended historical imports to create only source-backed ESPN identities and canonical historical fantasy totals when components are sufficient.
- Removed hidden Pick 6 kickoff mutation, shows scheduled slates with approved West Georgia Cornhole public branding, and restores Report Bug navigation.

### Safety

All data commands remain dry-run by default and require `--apply` for writes. No provider network clients, Railway changes, production data writes, or deployments are included. The sealed revision-4 schedule workbook now validates all four required Week 1 kickoff timestamps; Pick 6 publication remains separately guarded and no data has been applied.

### Validation

- `PYTHONPATH=. uv run pytest -q` — 501 passed
- `PYTHONPATH=. uv run pytest -q tests/scripts` — 62 passed
- `npm --prefix web test` — 198 passed
- `npm --prefix web run typecheck`
- `npm --prefix web run build`
- `npm --prefix web run test:e2e` — passed
- `docker-clean-boot` local equivalent — passed
- `./scripts/run_real_stack_e2e.sh` — 2 passed
